### PR TITLE
Add UUID field and parsing support for most of the elements

### DIFF
--- a/autosar/element.py
+++ b/autosar/element.py
@@ -1,7 +1,7 @@
 import autosar.base
 
 class Element:
-    def __init__(self, name, parent = None, adminData = None, category = None):
+    def __init__(self, name, parent = None, adminData = None, category = None, uuid = None):
         if isinstance(adminData, dict):
             adminDataObj=autosar.base.createAdminData(adminData)
         else:
@@ -12,6 +12,7 @@ class Element:
         self.adminData=adminDataObj
         self.parent=parent
         self.category=category
+        self.uuid=uuid
 
     @property
     def ref(self):

--- a/autosar/parser/behavior_parser.py
+++ b/autosar/parser/behavior_parser.py
@@ -1,5 +1,5 @@
 import autosar.behavior
-from autosar.parser.parser_base import ElementParser
+from autosar.parser.parser_base import ElementParser, parseElementUUID
 from autosar.parser.constant_parser import ConstantParser
 
 class BehaviorParser(ElementParser):
@@ -15,6 +15,7 @@ class BehaviorParser(ElementParser):
         else:
             return []
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         if (self.version >=3.0) and (self.version < 4.0) and xmlElement.tag == 'INTERNAL-BEHAVIOR':
             return self.parseInternalBehavior(xmlElement, parent)
@@ -23,6 +24,7 @@ class BehaviorParser(ElementParser):
         else:
             return None
 
+    @parseElementUUID
     def parseInternalBehavior(self,xmlRoot,parent):
         """AUTOSAR 3 Internal Behavior"""
         assert(xmlRoot.tag == 'INTERNAL-BEHAVIOR')
@@ -98,6 +100,7 @@ class BehaviorParser(ElementParser):
                     raise NotImplementedError(xmlNode.tag)
             return internalBehavior
 
+    @parseElementUUID
     def parseSWCInternalBehavior(self, xmlRoot, parent):
         """AUTOSAR 4 internal behavior"""
         assert(xmlRoot.tag == 'SWC-INTERNAL-BEHAVIOR')
@@ -193,6 +196,7 @@ class BehaviorParser(ElementParser):
                     raise NotImplementedError(xmlElem.tag)
             return internalBehavior
 
+    @parseElementUUID
     def parseRunnableEntity(self, xmlRoot, parent):
         xmlDataReceivePoints = None
         xmlDataSendPoints = None
@@ -375,6 +379,7 @@ class BehaviorParser(ElementParser):
                 raise NotImplementedError(xmlElem.tag)
         return autosar.behavior.ModeAccessPoint(name, modeGroupInstanceRef)
 
+    @parseElementUUID
     def _parseModeSwitchPoint(self, xmlRoot):
         assert(xmlRoot.tag == 'MODE-SWITCH-POINT')
         (name, modeGroupInstanceRef) = (None, None)
@@ -387,6 +392,7 @@ class BehaviorParser(ElementParser):
                 raise NotImplementedError(xmlElem.tag)
         return autosar.behavior.ModeSwitchPoint(name, modeGroupInstanceRef)
 
+    @parseElementUUID
     def _parseVariableAccess(self, xmlRoot):
         assert(xmlRoot.tag == 'VARIABLE-ACCESS')
         (name, variableAccess) = (None, None)
@@ -399,6 +405,7 @@ class BehaviorParser(ElementParser):
                 raise NotImplementedError(xmlElem.tag)
         return autosar.behavior.VariableAccess(name, variableAccess.portPrototypeRef, variableAccess.targetDataPrototypeRef)
 
+    @parseElementUUID
     def parseParameterAccessPoint(self, xmlRoot, parent = None):
         assert(xmlRoot.tag == 'PARAMETER-ACCESS')
         (name, accessedParameter, swDataDefProps) = (None, None, None)
@@ -525,12 +532,14 @@ class BehaviorParser(ElementParser):
         else:
             raise RuntimeError('Parse Error: <CONTEXT-PORT-REF DEST>, <CONTEXT-MODE-DECLARATION-GROUP-PROTOTYPE-REF> and <TARGET-MODE-DECLARATION-REF> must be defined')
 
+    @parseElementUUID
     def parseInitEvent(self,xmlNode,parent=None):
         name = self.parseTextNode(xmlNode.find('SHORT-NAME'))
         startOnEventRef = self.parseTextNode(xmlNode.find('START-ON-EVENT-REF'))
         initEvent=autosar.behavior.InitEvent(name, startOnEventRef, parent)
         return initEvent
 
+    @parseElementUUID
     def parseModeSwitchEvent(self,xmlNode,parent=None):
         """parses AUTOSAR3 <MODE-SWITCH-EVENT>"""
         if self.version < 4.0:
@@ -558,6 +567,7 @@ class BehaviorParser(ElementParser):
             raise NotImplementedError('version: '+self.version)
         return modeSwitchEvent
 
+    @parseElementUUID
     def parseModeSwitchedAckEvent(self, xmlNode, parent = None):
         if self.version < 4.0:
             raise NotImplementedError(xmlNode.tag)
@@ -580,6 +590,7 @@ class BehaviorParser(ElementParser):
                 modeSwitchEvent.disabledInModes = self._parseDisabledModesInstanceRefs(xmlDisabledModeRefs, parent)
             return modeSwitchEvent
 
+    @parseElementUUID
     def parseTimingEvent(self,xmlNode,parent=None):
         (name, startOnEventRef, period, xmlModeDepency, xmlDisabledModeRefs) = (None, None, None, None, None)
         for xmlElem in xmlNode.findall('./*'):
@@ -606,6 +617,7 @@ class BehaviorParser(ElementParser):
         else:
             raise RuntimeError('Parse error: <SHORT-NAME> and <START-ON-EVENT-REF> and <PERIOD> must be defined')
 
+    @parseElementUUID
     def parseDataReceivedEvent(self,xmlRoot,parent=None):
         name = self.parseTextNode(xmlRoot.find('SHORT-NAME'))
         startOnEventRef = self.parseTextNode(xmlRoot.find('START-ON-EVENT-REF'))
@@ -618,6 +630,7 @@ class BehaviorParser(ElementParser):
         dataReceivedEvent.dataInstanceRef=dataInstanceRef
         return dataReceivedEvent
 
+    @parseElementUUID
     def parseOperationInvokedEvent(self,xmlRoot,parent=None):
         (name, startOnEventRef, modeDependency, operationInstanceRef) = (None, None, None, None)
         for xmlElem in xmlRoot.findall('./*'):
@@ -700,6 +713,7 @@ class BehaviorParser(ElementParser):
             serviceCallPorts.append(roleBasedRPortAssignment)
         return serviceCallPorts
 
+    @parseElementUUID
     def parseCalPrmElemPrototype(self, xmlRoot, parent):
         """
         parses <CALPRM-ELEMENT-PROTOTYPE>
@@ -751,6 +765,7 @@ class BehaviorParser(ElementParser):
         retval.operationInstanceRefs=operationInstanceRefs
         return retval
 
+    @parseElementUUID
     def parseAccessedVariable(self, xmlRoot):
         assert(xmlRoot.tag == 'ACCESSED-VARIABLE')
         xmlPortPrototypeRef = xmlRoot.find('./AUTOSAR-VARIABLE-IREF/PORT-PROTOTYPE-REF')
@@ -759,6 +774,7 @@ class BehaviorParser(ElementParser):
         assert (xmlTargetDataPrototypeRef is not None)
         return autosar.behavior.VariableAccess(self.parseTextNode(xmlRoot.find('SHORT-NAME')),self.parseTextNode(xmlPortPrototypeRef), self.parseTextNode(xmlTargetDataPrototypeRef))
 
+    @parseElementUUID
     def parseSwcServiceDependency(self, xmlRoot, parent = None):
         """parses <SWC-SERVICE-DEPENDENCY>"""
         assert(xmlRoot.tag == 'SWC-SERVICE-DEPENDENCY')
@@ -801,6 +817,7 @@ class BehaviorParser(ElementParser):
         return swcServiceDependency
 
 
+    @parseElementUUID
     def parseParameterDataPrototype(self, xmlRoot, parent = None):
         """parses <PARAMETER-DATA-PROTOTYPE> (AUTOSAR 4)"""
         assert(xmlRoot.tag == 'PARAMETER-DATA-PROTOTYPE')
@@ -831,6 +848,7 @@ class BehaviorParser(ElementParser):
         self.pop(obj)
         return obj
 
+    @parseElementUUID
     def parseServiceNeeds(self, xmlRoot, parent = None):
         """parses <SERVICE-NEEDS> (AUTOSAR 4)"""
         assert(xmlRoot.tag == 'SERVICE-NEEDS')
@@ -956,6 +974,7 @@ class BehaviorParser(ElementParser):
                 targetDataPrototypeRef = self.parseTextNode(xmlTargetDataPrototypeRef)
         return localVariableRef, portPrototypeRef, targetDataPrototypeRef
 
+    @parseElementUUID
     def parseNvBlockSWCnvBlockDescriptor(self, xmlRoot, parent):
         """AUTOSAR 4 NV-BLOCK-DESCRIPTOR"""
         assert(xmlRoot.tag == 'NV-BLOCK-DESCRIPTOR')

--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -2,7 +2,7 @@ import sys
 from autosar.base import splitRef, hasAdminData, parseAdminDataNode
 import autosar.component
 from autosar.parser.behavior_parser import BehaviorParser
-from autosar.parser.parser_base import ElementParser
+from autosar.parser.parser_base import ElementParser, parseElementUUID
 from autosar.parser.constant_parser import ConstantParser
 
 def _getDataElemNameFromComSpec(xmlElem,portInterfaceRef):
@@ -79,6 +79,7 @@ class ComponentTypeParser(ElementParser):
     def getSupportedTags(self):
         return self.switcher.keys()
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         parseFunc = self.switcher.get(xmlElement.tag)
         if parseFunc is not None:
@@ -86,6 +87,7 @@ class ComponentTypeParser(ElementParser):
         else:
             return None
 
+    @parseElementUUID
     def parseSoftwareComponent(self, xmlRoot, parent=None):
         componentType=None
         handledTags = ['SHORT-NAME']
@@ -226,6 +228,7 @@ class ComponentTypeParser(ElementParser):
                             raise NotImplementedError(xmlItem.tag)
                 componentType.providePorts.append(port)
 
+    @parseElementUUID
     def parseCompositionType(self, xmlRoot, parent=None):
         """
         parses COMPOSITION-TYPE

--- a/autosar/parser/constant_parser.py
+++ b/autosar/parser/constant_parser.py
@@ -232,6 +232,8 @@ class ConstantParser(ElementParser):
         unitRef = None
         valueList = []
         sizeList = []
+        category = None
+        swAxisIndex = None
         for xmlElem in xmlRoot.findall('./*'):
             if xmlElem.tag == 'UNIT-REF':
                 unitRef = self.parseTextNode(xmlElem)
@@ -248,11 +250,11 @@ class ConstantParser(ElementParser):
                     else:
                         raise NotImplementedError(xmlChild.tag)
             elif xmlElem.tag == 'CATEGORY':
-                cat = self.parseTextNode(xmlElem)
+                category = self.parseTextNode(xmlElem)
             elif xmlElem.tag == 'SW-AXIS-INDEX':
-                swAxIndex = self.parseNumberNode(xmlElem)
+                swAxisIndex = self.parseNumberNode(xmlElem)
             else:
                 raise NotImplementedError(xmlElem.tag)
         if len(valueList)==0:
             valueList = None
-        return autosar.constant.SwAxisCont(valueList, unitRef, category=cat, swAxisIndex=swAxIndex, swArraySize=sizeList)
+        return autosar.constant.SwAxisCont(valueList, unitRef, category=category, swAxisIndex=swAxisIndex, swArraySize=sizeList)

--- a/autosar/parser/constant_parser.py
+++ b/autosar/parser/constant_parser.py
@@ -1,7 +1,7 @@
 from autosar.element import Element
 import autosar.constant
 from autosar.base import hasAdminData,parseAdminDataNode
-from autosar.parser.parser_base import ElementParser
+from autosar.parser.parser_base import ElementParser, parseElementUUID
 
 class ConstantParser(ElementParser):
     """
@@ -13,12 +13,14 @@ class ConstantParser(ElementParser):
     def getSupportedTags(self):
         return ['CONSTANT-SPECIFICATION']
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         if xmlElement.tag == 'CONSTANT-SPECIFICATION':
             return self.parseConstantSpecification(xmlElement, parent)
         else:
             return None
 
+    @parseElementUUID
     def parseConstantSpecification(self, xmlElem, rootProject=None, parent=None):
         assert(xmlElem.tag == 'CONSTANT-SPECIFICATION')
         (xmlValue, xmlValueSpec) = (None, None)
@@ -48,6 +50,7 @@ class ConstantParser(ElementParser):
         self.pop(retval)
         return retval
 
+    @parseElementUUID
     def _parseValueV3(self, xmlValue, parent):
         constantValue = None
         xmlName = xmlValue.find('SHORT-NAME')
@@ -126,6 +129,7 @@ class ConstantParser(ElementParser):
         else:
             raise RuntimeError("value must not be None")
 
+    @parseElementUUID
     def _parseRecordValueSpecification(self, xmlValue, parent):
         (label, xmlFields) = (None, None)
         for xmlElem in xmlValue.findall('./*'):

--- a/autosar/parser/datatype_parser.py
+++ b/autosar/parser/datatype_parser.py
@@ -1,5 +1,5 @@
 import sys
-from autosar.parser.parser_base import ElementParser
+from autosar.parser.parser_base import ElementParser, parseElementUUID
 import autosar.datatype
 
 class DataTypeParser(ElementParser):
@@ -27,6 +27,7 @@ class DataTypeParser(ElementParser):
     def getSupportedTags(self):
         return self.switcher.keys()
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         parseFunc = self.switcher.get(xmlElement.tag)
         if parseFunc is not None:
@@ -35,6 +36,7 @@ class DataTypeParser(ElementParser):
             return None
 
 
+    @parseElementUUID
     def parseIntegerType(self,root,parent=None):
         if self.version>=3.0:
             name=root.find("./SHORT-NAME").text
@@ -51,6 +53,7 @@ class DataTypeParser(ElementParser):
                         raise NotImplementedError(elem.tag)
             return dataType
 
+    @parseElementUUID
     def parseRecordType(self,root,parent=None):
         if self.version>=3.0:
             elements = []
@@ -63,6 +66,7 @@ class DataTypeParser(ElementParser):
             self.parseDesc(root,dataType)
             return dataType
 
+    @parseElementUUID
     def parseArrayType(self,root,parent=None):
         if self.version>=3.0:
             name=root.find("./SHORT-NAME").text
@@ -72,6 +76,7 @@ class DataTypeParser(ElementParser):
             self.parseDesc(root,dataType)
             return dataType;
 
+    @parseElementUUID
     def parseBooleanType(self,root,parent=None):
         if self.version>=3:
             name=root.find("./SHORT-NAME").text
@@ -79,6 +84,7 @@ class DataTypeParser(ElementParser):
             self.parseDesc(root,dataType)
             return dataType
 
+    @parseElementUUID
     def parseStringType(self,root,parent=None):
         if self.version>=3.0:
             name=root.find("./SHORT-NAME").text
@@ -89,6 +95,7 @@ class DataTypeParser(ElementParser):
             self.parseDesc(root,dataType)
             return dataType
 
+    @parseElementUUID
     def parseRealType(self,root,parent=None):
         if self.version>=3.0:
             name=root.find("./SHORT-NAME").text
@@ -108,6 +115,7 @@ class DataTypeParser(ElementParser):
             self.parseDesc(root,dataType)
             return dataType
 
+    @parseElementUUID
     def parseDataConstraint(self, xmlRoot, parent=None):
         assert (xmlRoot.tag == 'DATA-CONSTR')
         rules=[]
@@ -150,6 +158,7 @@ class DataTypeParser(ElementParser):
             'upperLimitType': upperLimitType}
 
 
+    @parseElementUUID
     def parseImplementationDataType(self, xmlRoot, parent=None):
         assert (xmlRoot.tag == 'IMPLEMENTATION-DATA-TYPE')
         variantProps, typeEmitter, parseTextNode, dynamicArraySizeProfile, subElementsXML, symbolProps = None, None, None, None, None, None
@@ -194,6 +203,7 @@ class DataTypeParser(ElementParser):
                 raise NotImplementedError(xmlElem.tag)
         return elements
 
+    @parseElementUUID
     def parseImplementationDataTypeElement(self, xmlRoot, parent):
         assert (xmlRoot.tag == 'IMPLEMENTATION-DATA-TYPE-ELEMENT')
         (arraySize, arraySizeSemantics, variants) = (None, None, None)
@@ -214,6 +224,7 @@ class DataTypeParser(ElementParser):
         return elem
 
 
+    @parseElementUUID
     def parseSwBaseType(self, xmlRoot, parent = None):
         assert (xmlRoot.tag == 'SW-BASE-TYPE')
         baseTypeSize, baseTypeEncoding, nativeDeclaration = None, None, None
@@ -235,6 +246,7 @@ class DataTypeParser(ElementParser):
         self.pop(elem)
         return elem
 
+    @parseElementUUID
     def parseDataTypeMappingSet(self, xmlRoot, parent = None):
         assert (xmlRoot.tag == 'DATA-TYPE-MAPPING-SET')
         (name, dataTypeMaps, adminData) = (None, None, None)
@@ -270,6 +282,7 @@ class DataTypeParser(ElementParser):
             elem.add(mapping)
         return elem
 
+    @parseElementUUID
     def parseApplicationPrimitiveDataType(self, xmlRoot, parent = None):
         assert (xmlRoot.tag == 'APPLICATION-PRIMITIVE-DATA-TYPE')
         variantProps = None
@@ -285,6 +298,7 @@ class DataTypeParser(ElementParser):
         self.pop(elem)
         return elem
 
+    @parseElementUUID
     def parseApplicationArrayDataType(self, xmlRoot, parent = None):
         assert (xmlRoot.tag == 'APPLICATION-ARRAY-DATA-TYPE')
         element, variantProps = None, None
@@ -304,6 +318,7 @@ class DataTypeParser(ElementParser):
         self.pop(elem)
         return elem
 
+    @parseElementUUID
     def parseApplicationArrayElement(self, xmlRoot):
         assert (xmlRoot.tag == 'ELEMENT')
         (typeRef, arraySize, sizeHandling, sizeSemantics) = (None, None, None, None)
@@ -323,6 +338,7 @@ class DataTypeParser(ElementParser):
         self.pop(elem)
         return elem
 
+    @parseElementUUID
     def parseApplicationRecordDataTypeXML(self, xmlRoot, parent = None):
         assert (xmlRoot.tag == 'APPLICATION-RECORD-DATA-TYPE')
         elementsXML, variantProps = None, None
@@ -344,6 +360,7 @@ class DataTypeParser(ElementParser):
         self.pop(elem)
         return elem
 
+    @parseElementUUID
     def _parseApplicationRecordElementXML(self, xmlRoot, parent):
         assert (xmlRoot.tag == 'APPLICATION-RECORD-ELEMENT')
         typeRef, variantProps = None, None
@@ -391,12 +408,14 @@ class DataTypeSemanticsParser(ElementParser):
     def getSupportedTags(self):
         return ['COMPU-METHOD']
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         if xmlElement.tag == 'COMPU-METHOD':
             return self._parseCompuMethodXML(xmlElement, parent)
         else:
             return None
 
+    @parseElementUUID
     def _parseCompuMethodXML(self, xmlRoot, parent=None):
         assert (xmlRoot.tag == 'COMPU-METHOD')
         compuInternalToPhys, compuPhysToInternal, unitRef = None, None, None
@@ -421,6 +440,7 @@ class DataTypeSemanticsParser(ElementParser):
             compuMethod.physToInt = compuPhysToInternal
         return compuMethod
 
+    @parseElementUUID
     def _parseComputationXML(self, xmlRoot):
         assert (xmlRoot.tag == 'COMPU-INTERNAL-TO-PHYS') or (xmlRoot.tag == 'COMPU-PHYS-TO-INTERNAL')
         computation = autosar.datatype.Computation()
@@ -510,12 +530,14 @@ class DataTypeUnitsParser(ElementParser):
     def getSupportedTags(self):
         return ['UNIT']
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         if xmlElement.tag == 'UNIT':
             return self._parseUnit(xmlElement, parent)
         else:
             return None
 
+    @parseElementUUID
     def _parseUnit(self, xmlRoot, parent=None):
         assert (xmlRoot.tag == 'UNIT')
         name = self.parseTextNode(xmlRoot.find("./SHORT-NAME"))

--- a/autosar/parser/mode_parser.py
+++ b/autosar/parser/mode_parser.py
@@ -1,5 +1,5 @@
 import sys
-from autosar.parser.parser_base import ElementParser
+from autosar.parser.parser_base import ElementParser, parseElementUUID
 import autosar.datatype
 
 class ModeDeclarationParser(ElementParser):
@@ -18,6 +18,7 @@ class ModeDeclarationParser(ElementParser):
     def getSupportedTags(self):
         return self.switcher.keys()
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         parseFunc = self.switcher.get(xmlElement.tag)
         if parseFunc is not None:
@@ -25,6 +26,7 @@ class ModeDeclarationParser(ElementParser):
         else:
             return None
 
+    @parseElementUUID
     def parseModeDeclarationGroup(self,xmlRoot,rootProject=None,parent=None):
         assert(xmlRoot.tag == 'MODE-DECLARATION-GROUP')
         name = self.parseTextNode(xmlRoot.find("./SHORT-NAME"))

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -3,6 +3,7 @@ from collections import deque
 from autosar.base import (AdminData, SpecialDataGroup, SpecialData, SwDataDefPropsConditional, SwPointerTargetProps, SymbolProps)
 import autosar.element
 import xml
+from functools import wraps
 
 def _parseBoolean(value):
     if value is None:
@@ -20,6 +21,7 @@ def parseElementUUID(parser_func):
     argument and returns a autosar.element.Element. In case the xml element contains
     the UUID attribute, this will be inserted into the Autosar Element.
     """
+    @wraps(parser_func)
     def parseUUID(*args, **kwargs):
 
         # call original parser function

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -346,7 +346,7 @@ def parseElementUUID(parser_func):
         # retrieve the UUID from the xml element and attach it to the Autosar Element
         xmlElementArg = xmlElementArgs[0]
         if 'UUID' in xmlElementArg.attrib:
-            result.uuid = xmlElementArg.attrib
+            result.uuid = xmlElementArg.attrib['UUID'].lower()
         return result
 
     return parseUUID

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -2,6 +2,7 @@ import abc
 from collections import deque
 from autosar.base import (AdminData, SpecialDataGroup, SpecialData, SwDataDefPropsConditional, SwPointerTargetProps, SymbolProps)
 import autosar.element
+import xml
 
 def _parseBoolean(value):
     if value is None:
@@ -311,3 +312,41 @@ class ElementParser(BaseParser, metaclass=abc.ABCMeta):
         parent: the parent object (usually a package object)
         Should return an object derived from autosar.element.Element
         """
+
+def parseElementUUID(parser_func):
+    """
+    Decorator that adds parsing of the UUID field for autosar.element.Element
+
+    The decorator should be added to methods that parse an xml.etree.ElementTree.Element
+    argument and returns a autosar.element.Element. In case the xml element contains
+    the UUID attribute, this will be inserted into the Autosar Element.
+    """
+    def parseUUID(*args, **kwargs):
+
+        # call original parser function
+        result = parser_func(*args, **kwargs)
+
+        # if the result is not an Autosar Element, simply return
+        if not isinstance(result, autosar.element.Element):
+            return result
+    
+        # search for an argument of type xml.etree.ElementTree.Element    
+        xmlElementArgs = []
+        for arg in args:
+            if isinstance(arg, xml.etree.ElementTree.Element):
+                xmlElementArgs.append(arg)
+        for _, arg in kwargs.items():
+            if isinstance(arg, xml.etree.ElementTree.Element):
+                xmlElementArgs.append(arg)
+        
+        # if we cannot determine in a unique way which argument to use, just return
+        if len(xmlElementArgs) != 1:
+            return result
+    
+        # retrieve the UUID from the xml element and attach it to the Autosar Element
+        xmlElementArg = xmlElementArgs[0]
+        if 'UUID' in xmlElementArg.attrib:
+            result.uuid = xmlElementArg.attrib
+        return result
+
+    return parseUUID

--- a/autosar/parser/portinterface_parser.py
+++ b/autosar/parser/portinterface_parser.py
@@ -3,7 +3,7 @@ import autosar.portinterface
 import autosar.base
 import autosar.element
 import autosar.mode
-from autosar.parser.parser_base import ElementParser
+from autosar.parser.parser_base import ElementParser, parseElementUUID
 
 class PortInterfacePackageParser(ElementParser):
     def __init__(self, version=3.0):
@@ -26,6 +26,7 @@ class PortInterfacePackageParser(ElementParser):
     def getSupportedTags(self):
         return self.switcher.keys()
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         parseFunc = self.switcher.get(xmlElement.tag)
         if parseFunc is not None:
@@ -35,6 +36,7 @@ class PortInterfacePackageParser(ElementParser):
 
 
 
+    @parseElementUUID
     def parseSenderReceiverInterface(self, xmlRoot, parent=None):
         assert (xmlRoot.tag == 'SENDER-RECEIVER-INTERFACE')
         (isService, serviceKind, dataElements, modeGroups, invalidationPolicys) = (False, None, None, None, None)
@@ -72,6 +74,7 @@ class PortInterfacePackageParser(ElementParser):
             self.pop()
             return None
 
+    @parseElementUUID
     def _parseDataElements(self, xmlRoot):
         dataElements = []
         if self.version >= 4.0:
@@ -89,6 +92,7 @@ class PortInterfacePackageParser(ElementParser):
                 raise NotImplementedError(xmlElem.tag)
         return dataElements
 
+    @parseElementUUID
     def _parseModeGroups(self, xmlRoot):
         assert(xmlRoot.tag == 'MODE-GROUPS')
         modeGroups = []
@@ -121,6 +125,7 @@ class PortInterfacePackageParser(ElementParser):
                 raise NotImplementedError(xmlChild.tag)
         return policyList
 
+    @parseElementUUID
     def _parseDataElementPrototype(self, xmlRoot):
         assert(xmlRoot.tag == 'DATA-ELEMENT-PROTOTYPE')
         (typeRef, isQueued) = (None, False)
@@ -154,6 +159,7 @@ class PortInterfacePackageParser(ElementParser):
         else:
             raise RuntimeError('DATA-ELEMENT-REF and HANDLE-INVALID must not be None')
 
+    @parseElementUUID
     def parseCalPrmInterface(self,xmlRoot,parent=None):
         assert(xmlRoot.tag=='CALPRM-INTERFACE')
         xmlName = xmlRoot.find("./SHORT-NAME")
@@ -173,6 +179,7 @@ class PortInterfacePackageParser(ElementParser):
                     portInterface.append(parameter)
             return portInterface
 
+    @parseElementUUID
     def parseClientServerInterface(self,xmlRoot,parent=None):
         assert(xmlRoot.tag=='CLIENT-SERVER-INTERFACE')
         name = self.parseTextNode(xmlRoot.find('SHORT-NAME'))
@@ -207,6 +214,7 @@ class PortInterfacePackageParser(ElementParser):
                     raise NotImplementedError(xmlElem.tag)
             return portInterface
 
+    @parseElementUUID
     def parseParameterInterface(self,xmlRoot,parent=None):
         (name, adminData, isService, xmlParameters) = (None, None, False, None)
         for xmlElem in xmlRoot.findall('./*'):
@@ -233,6 +241,7 @@ class PortInterfacePackageParser(ElementParser):
             return portInterface
 
 
+    @parseElementUUID
     def parseModeSwitchInterface(self,xmlRoot,parent=None):
         (name, adminData, desc, isService, xmlModeGroup) = (None, None, None, False, None)
         for xmlElem in xmlRoot.findall('./*'):
@@ -253,6 +262,7 @@ class PortInterfacePackageParser(ElementParser):
             portInterface.modeGroup=self._parseModeGroup(xmlModeGroup, portInterface)
             return portInterface
 
+    @parseElementUUID
     def _parseModeGroup(self, xmlModeGroup, parent):
         if self.version>=4.0:
             assert(xmlModeGroup.tag == "MODE-GROUP")
@@ -262,6 +272,7 @@ class PortInterfacePackageParser(ElementParser):
         typeRef = self.parseTextNode(xmlModeGroup.find('TYPE-TREF'))
         return autosar.mode.ModeGroup(name, typeRef, parent)
 
+    @parseElementUUID
     def _parseOperationPrototype(self, xmlOperation, parent):
         (name, xmlDesc, xmlArguments, xmlPossibleErrorRefs) = (None, None, None, None)
         for xmlElem in xmlOperation.findall('./*'):
@@ -304,6 +315,7 @@ class PortInterfacePackageParser(ElementParser):
                         raise NotImplementedError(xmlChild.tag)
             return operation
 
+    @parseElementUUID
     def _parseOperationArgumentV3(self, xmlArgument, parent):
         (name, typeRef, direction) = (None, None, None)
         for xmlElem in xmlArgument.findall('./*'):
@@ -320,6 +332,7 @@ class PortInterfacePackageParser(ElementParser):
         else:
             raise RuntimeError('SHORT-NAME, TYPE-TREF and DIRECTION must have valid values')
 
+    @parseElementUUID
     def _parseOperationArgumentV4(self, xmlArgument, parent):
         (argument, typeRef, direction, props_variants, serverArgumentImplPolicy) = (None, None, None, None, None)
         self.push()
@@ -343,11 +356,13 @@ class PortInterfacePackageParser(ElementParser):
         self.pop(argument)
         return argument
 
+    @parseElementUUID
     def _parseApplicationError(self, xmlElem, parent):
         name=self.parseTextNode(xmlElem.find("./SHORT-NAME"))
         errorCode=self.parseTextNode(xmlElem.find("./ERROR-CODE"))
         return autosar.portinterface.ApplicationError(name, errorCode, parent)
 
+    @parseElementUUID
     def _parseParameterDataPrototype(self, xmlElem, parent):
         (name, adminData, typeRef, props_variants) = (None, None, None, None)
         for xmlElem in xmlElem.findall('./*'):
@@ -369,6 +384,7 @@ class PortInterfacePackageParser(ElementParser):
                 parameter.swAddressMethodRef = props_variants[0].swAddressMethodRef
             return parameter
 
+    @parseElementUUID
     def parseNvDataInterface(self, xmlRoot, parent=None):
         assert (xmlRoot.tag == 'NV-DATA-INTERFACE')
         (isService, serviceKind, nvDatas) = (False, None, None)
@@ -402,12 +418,14 @@ class SoftwareAddressMethodParser(ElementParser):
     def getSupportedTags(self):
         return ['SW-ADDR-METHOD']
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         if xmlElement.tag == 'SW-ADDR-METHOD':
             return self.parseSWAddrMethod(xmlElement, parent)
         else:
             return None
 
+    @parseElementUUID
     def parseSWAddrMethod(self,xmlRoot,rootProject=None,parent=None):
         assert(xmlRoot.tag == 'SW-ADDR-METHOD')
         name = xmlRoot.find("./SHORT-NAME").text

--- a/autosar/parser/signal_parser.py
+++ b/autosar/parser/signal_parser.py
@@ -1,6 +1,6 @@
 from autosar.base import parseXMLFile,splitRef,parseTextNode,parseIntNode
 from autosar.signal import *
-from autosar.parser.parser_base import ElementParser
+from autosar.parser.parser_base import ElementParser, parseElementUUID
 
 class SignalParser(ElementParser):
     def __init__(self,version=3):
@@ -17,6 +17,7 @@ class SignalParser(ElementParser):
     def getSupportedTags(self):
         return self.switcher.keys()
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         parseFunc = self.switcher.get(xmlElement.tag)
         if parseFunc is not None:
@@ -24,6 +25,7 @@ class SignalParser(ElementParser):
         else:
             return None
 
+    @parseElementUUID
     def parseSystemSignal(self,xmlRoot,parent=None):
         """
         parses <SYSTEM-SIGNAL>
@@ -53,6 +55,7 @@ class SignalParser(ElementParser):
         else:
             raise RuntimeError('failed to parse %s'%xmlRoot.tag)
 
+    @parseElementUUID
     def parseSystemSignalGroup(self, xmlRoot, parent=None):
         name,systemSignalRefs=None,None
         for elem in xmlRoot.findall('./*'):

--- a/autosar/parser/swc_implementation_parser.py
+++ b/autosar/parser/swc_implementation_parser.py
@@ -4,7 +4,7 @@ Implements the class SwcImplementationParser
 import sys
 from autosar.base import splitRef, hasAdminData, parseAdminDataNode
 import autosar.component
-from autosar.parser.parser_base import ElementParser
+from autosar.parser.parser_base import ElementParser, parseElementUUID
 
 class SwcImplementationParser(ElementParser):
     """
@@ -18,6 +18,7 @@ class SwcImplementationParser(ElementParser):
     def getSupportedTags(self):
         return [self.classTag]
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         """
         parser for the class.
@@ -95,6 +96,7 @@ class SwcImplementationParser(ElementParser):
 
         return implementation
 
+    @parseElementUUID
     def parseCodeDescriptor(self, xmlElement, parent = None):
         """
         Parser for implementation code descriptor.
@@ -136,6 +138,7 @@ class SwcImplementationParser(ElementParser):
         self.pop(code)
         return code
 
+    @parseElementUUID
     def parseResourceConsumption(self, xmlElement, parent = None):
         """
         Parser for implementation resource consumption.
@@ -169,6 +172,7 @@ class SwcImplementationParser(ElementParser):
         self.pop(res)
         return res
 
+    @parseElementUUID
     def parseMemorySection(self, xmlElement, parent = None):
         """
         Parser for memory section.

--- a/autosar/parser/system_parser.py
+++ b/autosar/parser/system_parser.py
@@ -1,6 +1,6 @@
 from autosar.base import parseXMLFile,splitRef,parseTextNode,parseIntNode,hasAdminData,parseAdminDataNode
 from autosar.system import *
-from autosar.parser.parser_base import ElementParser
+from autosar.parser.parser_base import ElementParser, parseElementUUID
 
 class SystemParser(ElementParser):
     def __init__(self,version=3.0):
@@ -9,12 +9,14 @@ class SystemParser(ElementParser):
     def getSupportedTags(self):
         return ['SYSTEM']
 
+    @parseElementUUID
     def parseElement(self, xmlElement, parent = None):
         if xmlElement.tag == 'SYSTEM':
             return self.parseSystem(xmlElement, parent)
         else:
             return None
 
+    @parseElementUUID
     def parseSystem(self,xmlRoot,parent=None):
         """
         parses <SYSTEM>


### PR DESCRIPTION
This PR adds the ```uuid``` field to the ```autosar.element.Element``` class and adds support for parsing the UUID attribute from ARXML.

To reduce code modifications, the UUID parsing has been implemented via a decorator. The decorator can be attached to any parsing method that reads a ```xml.etree.ElementTree.Element``` (XML Element) and returns a corresponding ```autosar.element.Element``` (Autosar Element).