### PR TITLE
Support for nested Composite Implementation Data Types

### DIFF
--- a/autosar/behavior.py
+++ b/autosar/behavior.py
@@ -1408,9 +1408,9 @@ class SwcInternalBehavior(InternalBehaviorCommon):
             raise RuntimeError('Runnable {0.name} must have at least one mode switch point'.format(sourceRunnable))
         if len(ref[1])==0:
             #No '/' delimiter was used. This is OK only when the source runnable has only one modeSwitchPoint (no ambiguity)
-            if len(sourceRunnable.modeSwitchPoints) > 1:
-                raise ValueError('Ambiguous use of modeSwitchSource "{}". Please use pattern "RunnableName/PortName" in modeSwitchSource argument')
-            sourceModeSwitchPoint = sourceRunnable.modeSwitchPoints[0]
+                if len(sourceRunnable.modeSwitchPoints) > 1:
+                    raise ValueError('Ambiguous use of modeSwitchSource "{}". Please use pattern "RunnableName/PortName" in modeSwitchSource argument')
+                sourceModeSwitchPoint = sourceRunnable.modeSwitchPoints[0]
         else:
             #Search through all modeSwitchPoints to find port name that matches second half of the partition split
             modePortName = ref[2]

--- a/autosar/behavior.py
+++ b/autosar/behavior.py
@@ -1,4 +1,5 @@
 import copy
+import itertools
 import autosar.component
 import autosar.portinterface
 import autosar.base
@@ -1288,7 +1289,7 @@ class SwcInternalBehavior(InternalBehaviorCommon):
 
     def createSharedDataParameter(self, name, implementationTypeRef, swAddressMethodRef = None, swCalibrationAccess = None, initValue = None):
         """
-        AUTOSAR4: Creates a ParameterDataPrototype object and appends it to the internal parameterDataPrototype list
+        AUTOSAR4: Creates a ParameterDataPrototype object and appends it to the internal sharedParameterDataPrototype list
         """
         self._initSWC()
         ws = self.rootWS()
@@ -1301,7 +1302,7 @@ class SwcInternalBehavior(InternalBehaviorCommon):
 
     def createPerInstanceDataParameter(self, name, implementationTypeRef, swAddressMethodRef = None, swCalibrationAccess = None, initValue = None):
         """
-        AUTOSAR4: Creates a ParameterDataPrototype object and appends it to the internal parameterDataPrototype list
+        AUTOSAR4: Creates a ParameterDataPrototype object and appends it to the internal perInstanceParameterDataPrototype list
         """
         self._initSWC()
         ws = self.rootWS()
@@ -1342,12 +1343,12 @@ class SwcInternalBehavior(InternalBehaviorCommon):
         else:
             raise ValueError('%s: No per-instance-memory found with name "%s"'%(self.swc.name, perInstanceMemoryName))
         if defaultValueName is not None:
-            for param in self.sharedParameterDataPrototype:
+            for param in itertools.chain(self.sharedParameterDataPrototype, self.perInstanceParameterDataPrototype):
                 if param.name == defaultValueName:
                     serviceDependency.roleBasedDataAssignments.append(RoleBasedDataAssignment(defaultValueRole, localParameterRef = param.ref))
                     break
             else:
-                raise ValueError('%s: No shared data parameter found with name "%s"'%(self.swc.name, defaultValueName))
+                raise ValueError('%s: No data parameter found with name "%s"'%(self.swc.name, defaultValueName))
 
         self.serviceDependencies.append(serviceDependency)
         return serviceDependency

--- a/autosar/datatype.py
+++ b/autosar/datatype.py
@@ -425,9 +425,10 @@ class DataConstraint(Element):
                 return rule
 
 
-class ImplementationDataTypeVariantMixin():
+class ImplementationDataTypeBase(Element):
 
-    def __init__(self, *args, variantProps=None, **kwargs):
+    def __init__(self, name, parent, adminData, category, variantProps=None):
+        super().__init__(name, parent, adminData, category)
         self.variantProps = []
         if isinstance(variantProps, (autosar.base.SwDataDefPropsConditional,
                                      autosar.base.SwPointerTargetProps)):
@@ -468,30 +469,16 @@ class ImplementationDataTypeVariantMixin():
         else:
             raise RuntimeError('Element has no variantProps set')
 
-class ImplementationDataType(Element, ImplementationDataTypeVariantMixin):
+class ImplementationDataType(ImplementationDataTypeBase):
 
-    def tag(self, version=None):
-        return 'IMPLEMENTATION-DATA-TYPE'
+    def tag(self, version=None): return 'IMPLEMENTATION-DATA-TYPE'
 
-    def __init__(self,
-                 name,
-                 dynamicArraySizeProfile=None,
-                 typeEmitter=None,
-                 category='VALUE',
-                 parent=None,
-                 adminData=None,
-                 *args,
-                 **kwargs):
-        super().__init__(name, parent, adminData, category)
+    def __init__(self, name, variantProps = None, dynamicArraySizeProfile = None, typeEmitter = None, category='VALUE', parent = None, adminData = None):
+        super().__init__(name, parent, adminData, category, variantProps)
         self.dynamicArraySizeProfile = dynamicArraySizeProfile
         self.typeEmitter = typeEmitter
         self.subElements = []
         self.symbolProps = None
-        ImplementationDataTypeVariantMixin.__init__(self, name,
-                                                    dynamicArraySizeProfile,
-                                                    typeEmitter, category,
-                                                    parent, adminData, *args,
-                                                    **kwargs)
 
     def getTypeReference(self):
         """
@@ -518,20 +505,11 @@ class SwBaseType(Element):
         self.typeEncoding = typeEncoding
 
 
-class ImplementationDataTypeElement(Element,
-                                    ImplementationDataTypeVariantMixin):
+class ImplementationDataTypeElement(ImplementationDataTypeBase):
+    def tag(self, version=None): return 'IMPLEMENTATION-DATA-TYPE-ELEMENT'
 
-
-    def __init__(self,
-                 name,
-                 category=None,
-                 arraySize=None,
-                 arraySizeSemantics=None,
-                 parent=None,
-                 adminData=None,
-                 *args,
-                 **kwargs):
-        super().__init__(name, parent, adminData, category)
+    def __init__(self, name, category = None, arraySize = None, arraySizeSemantics = None, variantProps = None, parent = None, adminData = None)
+        super().__init__(name, parent, adminData, category, variantProps)
         self.arraySize = arraySize
         self.subElements = []
         if arraySize is not None:
@@ -541,10 +519,6 @@ class ImplementationDataTypeElement(Element,
                 self.arraySizeSemantics = 'FIXED-SIZE'
         else:
             self.arraySizeSemantics = None
-        ImplementationDataTypeVariantMixin.__init__(self, name, category,
-                                                    arraySize,
-                                                    arraySizeSemantics, parent,
-                                                    adminData, *args, **kwargs)
 
 
 class ApplicationDataType(Element):

--- a/autosar/datatype.py
+++ b/autosar/datatype.py
@@ -504,11 +504,10 @@ class SwBaseType(Element):
         self.nativeDeclaration = nativeDeclaration
         self.typeEncoding = typeEncoding
 
-
 class ImplementationDataTypeElement(ImplementationDataTypeBase):
     def tag(self, version=None): return 'IMPLEMENTATION-DATA-TYPE-ELEMENT'
 
-    def __init__(self, name, category = None, arraySize = None, arraySizeSemantics = None, variantProps = None, parent = None, adminData = None)
+    def __init__(self, name, category = None, arraySize = None, arraySizeSemantics = None, variantProps = None, parent = None, adminData = None):
         super().__init__(name, parent, adminData, category, variantProps)
         self.arraySize = arraySize
         self.subElements = []

--- a/autosar/datatype.py
+++ b/autosar/datatype.py
@@ -424,7 +424,6 @@ class DataConstraint(Element):
             if (isinstance(rule, InternalConstraint) and constraintType == 'internalConstraint') or (isinstance(rule, PhysicalConstraint) and constraintType == 'physicalConstraint'):
                 return rule
 
-
 class ImplementationDataTypeBase(Element):
 
     def __init__(self, name, parent, adminData, category, variantProps=None):

--- a/autosar/package.py
+++ b/autosar/package.py
@@ -1007,7 +1007,12 @@ class Package(object):
 
         targetProps = autosar.base.SwPointerTargetProps(targetCategory, autosar.base.SwDataDefPropsConditional(baseTypeRef = baseTypeRef, swImplPolicy=swImplPolicy))
         variantProps =  autosar.base.SwDataDefPropsConditional(swPointerTargetProps = targetProps)
-        implementationDataType = autosar.datatype.ImplementationDataType(name, variantProps, category = category, parent = self, adminData = adminDataObj)
+        implementationDataType = autosar.datatype.ImplementationDataType(
+            name,
+            variantProps=variantProps,
+            category=category,
+            parent=self,
+            adminData=adminDataObj)
         self.append(implementationDataType)
         return implementationDataType
 
@@ -1118,13 +1123,20 @@ class Package(object):
         compuMethodRef = None if compuMethodObj is None else compuMethodObj.ref
         dataConstraintRef = None if dataConstraintObj is None else dataConstraintObj.ref
 
-        variantProps = autosar.base.SwDataDefPropsConditional(swCalibrationAccess = swCalibrationAccess,
-                                                              compuMethodRef = compuMethodRef,
-                                                              dataConstraintRef = dataConstraintRef,
-                                                              baseTypeRef = baseTypeRef,
-                                                              implementationTypeRef = implementationTypeRef,
-                                                              unitRef = unitRef)
-        implementationDataType = autosar.datatype.ImplementationDataType(name, variantProps, typeEmitter=typeEmitter, category = category, parent = self, adminData = adminDataObj)
+        variantProps = autosar.base.SwDataDefPropsConditional(
+            swCalibrationAccess=swCalibrationAccess,
+            compuMethodRef=compuMethodRef,
+            dataConstraintRef=dataConstraintRef,
+            baseTypeRef=baseTypeRef,
+            implementationTypeRef=implementationTypeRef,
+            unitRef=unitRef)
+        implementationDataType = autosar.datatype.ImplementationDataType(
+            name,
+            variantProps=variantProps,
+            typeEmitter=typeEmitter,
+            category=category,
+            parent=self,
+            adminData=adminDataObj)
         self.append(implementationDataType)
         return implementationDataType
 
@@ -1143,7 +1155,11 @@ class Package(object):
             variantProps = autosar.base.SwDataDefPropsConditional(swCalibrationAccess = swCalibrationAccess)
         else:
             variantProps = None
-        dataType = autosar.datatype.ImplementationDataType(name, variantProps, category = category, adminData = adminData)
+        dataType = autosar.datatype.ImplementationDataType(
+            name,
+            variantProps=variantProps,
+            category=category,
+            adminData=adminData)
         for element in elements:
             if not isinstance(element, tuple):
                 raise ValueError('element must be a tuple')

--- a/autosar/package.py
+++ b/autosar/package.py
@@ -1007,12 +1007,7 @@ class Package(object):
 
         targetProps = autosar.base.SwPointerTargetProps(targetCategory, autosar.base.SwDataDefPropsConditional(baseTypeRef = baseTypeRef, swImplPolicy=swImplPolicy))
         variantProps =  autosar.base.SwDataDefPropsConditional(swPointerTargetProps = targetProps)
-        implementationDataType = autosar.datatype.ImplementationDataType(
-            name,
-            variantProps=variantProps,
-            category=category,
-            parent=self,
-            adminData=adminDataObj)
+        implementationDataType = autosar.datatype.ImplementationDataType(name, variantProps=variantProps, category=category, parent=self, adminData=adminDataObj)
         self.append(implementationDataType)
         return implementationDataType
 
@@ -1123,20 +1118,13 @@ class Package(object):
         compuMethodRef = None if compuMethodObj is None else compuMethodObj.ref
         dataConstraintRef = None if dataConstraintObj is None else dataConstraintObj.ref
 
-        variantProps = autosar.base.SwDataDefPropsConditional(
-            swCalibrationAccess=swCalibrationAccess,
-            compuMethodRef=compuMethodRef,
-            dataConstraintRef=dataConstraintRef,
-            baseTypeRef=baseTypeRef,
-            implementationTypeRef=implementationTypeRef,
-            unitRef=unitRef)
-        implementationDataType = autosar.datatype.ImplementationDataType(
-            name,
-            variantProps=variantProps,
-            typeEmitter=typeEmitter,
-            category=category,
-            parent=self,
-            adminData=adminDataObj)
+        variantProps = autosar.base.SwDataDefPropsConditional(swCalibrationAccess = swCalibrationAccess,
+                                                               compuMethodRef = compuMethodRef,
+                                                               dataConstraintRef = dataConstraintRef,
+                                                               baseTypeRef = baseTypeRef,
+                                                               implementationTypeRef = implementationTypeRef,
+                                                               unitRef = unitRef)
+        implementationDataType = autosar.datatype.ImplementationDataType(name, variantProps, typeEmitter=typeEmitter, category = category, parent = self, adminData = adminDataObj)
         self.append(implementationDataType)
         return implementationDataType
 

--- a/autosar/package.py
+++ b/autosar/package.py
@@ -1007,7 +1007,7 @@ class Package(object):
 
         targetProps = autosar.base.SwPointerTargetProps(targetCategory, autosar.base.SwDataDefPropsConditional(baseTypeRef = baseTypeRef, swImplPolicy=swImplPolicy))
         variantProps =  autosar.base.SwDataDefPropsConditional(swPointerTargetProps = targetProps)
-        implementationDataType = autosar.datatype.ImplementationDataType(name, variantProps=variantProps, category=category, parent=self, adminData=adminDataObj)
+        implementationDataType = autosar.datatype.ImplementationDataType(name, variantProps, category = category, parent = self, adminData = adminDataObj)
         self.append(implementationDataType)
         return implementationDataType
 
@@ -1119,11 +1119,11 @@ class Package(object):
         dataConstraintRef = None if dataConstraintObj is None else dataConstraintObj.ref
 
         variantProps = autosar.base.SwDataDefPropsConditional(swCalibrationAccess = swCalibrationAccess,
-                                                               compuMethodRef = compuMethodRef,
-                                                               dataConstraintRef = dataConstraintRef,
-                                                               baseTypeRef = baseTypeRef,
-                                                               implementationTypeRef = implementationTypeRef,
-                                                               unitRef = unitRef)
+                                                              compuMethodRef = compuMethodRef,
+                                                              dataConstraintRef = dataConstraintRef,
+                                                              baseTypeRef = baseTypeRef,
+                                                              implementationTypeRef = implementationTypeRef,
+                                                              unitRef = unitRef)
         implementationDataType = autosar.datatype.ImplementationDataType(name, variantProps, typeEmitter=typeEmitter, category = category, parent = self, adminData = adminDataObj)
         self.append(implementationDataType)
         return implementationDataType
@@ -1143,11 +1143,7 @@ class Package(object):
             variantProps = autosar.base.SwDataDefPropsConditional(swCalibrationAccess = swCalibrationAccess)
         else:
             variantProps = None
-        dataType = autosar.datatype.ImplementationDataType(
-            name,
-            variantProps=variantProps,
-            category=category,
-            adminData=adminData)
+        dataType = autosar.datatype.ImplementationDataType(name, variantProps, category = category, adminData = adminData)
         for element in elements:
             if not isinstance(element, tuple):
                 raise ValueError('element must be a tuple')

--- a/autosar/parser/behavior_parser.py
+++ b/autosar/parser/behavior_parser.py
@@ -373,7 +373,7 @@ class BehaviorParser(ElementParser):
                     runnableEntity.dataReadAccess.append(variableAccess)
                 else:
                     raise NotImplementedError(xmlElem.tag)
-
+        
         if xmlDataWriteAccess is not None:
             for xmlElem in xmlDataWriteAccess.findall('./*'):
                 if xmlElem.tag == 'VARIABLE-ACCESS':
@@ -391,7 +391,7 @@ class BehaviorParser(ElementParser):
                     runnableEntity.dataLocalReadAccess.append(variableAccess)
                 else:
                     raise NotImplementedError(xmlElem.tag)
-
+        
         if xmlLocalDataWriteAccess is not None:
             for xmlElem in xmlLocalDataWriteAccess.findall('./*'):
                 if xmlElem.tag == 'VARIABLE-ACCESS':
@@ -400,7 +400,7 @@ class BehaviorParser(ElementParser):
                     runnableEntity.dataLocalWriteAccess.append(variableAccess)
                 else:
                     raise NotImplementedError(xmlElem.tag)
-
+        
         if runnableEntity is not None:
             runnableEntity.adminData = adminData
         return runnableEntity
@@ -822,7 +822,7 @@ class BehaviorParser(ElementParser):
         retval=callType(name,timeout)
         retval.operationInstanceRefs=operationInstanceRefs
         return retval
-
+    
     def parseAsyncServerCallPoint(self, xmlRoot):
         """
         parses <ASYNCHRONOUS-SERVER-CALL-POINT>

--- a/autosar/parser/behavior_parser.py
+++ b/autosar/parser/behavior_parser.py
@@ -174,7 +174,7 @@ class BehaviorParser(ElementParser):
                         if xmlChildElem.tag == 'PARAMETER-DATA-PROTOTYPE':
                             tmp = self.parseParameterDataPrototype(xmlChildElem, internalBehavior)
                             if tmp is not None:
-                                internalBehavior.parameterDataPrototype.append(tmp)
+                                internalBehavior.sharedParameterDataPrototype.append(tmp)
                         else:
                             raise NotImplementedError(xmlChildElem.tag)
                 elif xmlElem.tag == 'EXCLUSIVE-AREAS':
@@ -185,7 +185,15 @@ class BehaviorParser(ElementParser):
                         else:
                             raise NotImplementedError(xmlChild.tag)
                 elif xmlElem.tag == 'PER-INSTANCE-PARAMETERS':
-                    pass #implement later
+                    for xmlChildElem in xmlElem.findall('./*'):
+                        if xmlChildElem.tag == 'PARAMETER-DATA-PROTOTYPE':
+                            tmp = self.parseParameterDataPrototype(
+                                xmlChildElem, internalBehavior)
+                            if tmp is not None:
+                                internalBehavior.perInstanceParameterDataPrototype.append(
+                                    tmp)
+                        else:
+                            raise NotImplementedError(xmlChildElem.tag)
                 elif xmlElem.tag == 'EXPLICIT-INTER-RUNNABLE-VARIABLES':
                     for xmlChild in xmlElem.findall('./*'):
                         if xmlChild.tag == 'VARIABLE-DATA-PROTOTYPE':
@@ -360,7 +368,7 @@ class BehaviorParser(ElementParser):
                     runnableEntity.dataReadAccess.append(variableAccess)
                 else:
                     raise NotImplementedError(xmlElem.tag)
-        
+
         if xmlDataWriteAccess is not None:
             for xmlElem in xmlDataWriteAccess.findall('./*'):
                 if xmlElem.tag == 'VARIABLE-ACCESS':
@@ -378,7 +386,7 @@ class BehaviorParser(ElementParser):
                     runnableEntity.dataLocalReadAccess.append(variableAccess)
                 else:
                     raise NotImplementedError(xmlElem.tag)
-        
+
         if xmlLocalDataWriteAccess is not None:
             for xmlElem in xmlLocalDataWriteAccess.findall('./*'):
                 if xmlElem.tag == 'VARIABLE-ACCESS':
@@ -387,7 +395,7 @@ class BehaviorParser(ElementParser):
                     runnableEntity.dataLocalWriteAccess.append(variableAccess)
                 else:
                     raise NotImplementedError(xmlElem.tag)
-        
+
         if runnableEntity is not None:
             runnableEntity.adminData = adminData
         return runnableEntity
@@ -809,7 +817,7 @@ class BehaviorParser(ElementParser):
         retval=callType(name,timeout)
         retval.operationInstanceRefs=operationInstanceRefs
         return retval
-    
+
     def parseAsyncServerCallPoint(self, xmlRoot):
         """
         parses <ASYNCHRONOUS-SERVER-CALL-POINT>

--- a/autosar/parser/datatype_parser.py
+++ b/autosar/parser/datatype_parser.py
@@ -206,7 +206,7 @@ class DataTypeParser(ElementParser):
     @parseElementUUID
     def parseImplementationDataTypeElement(self, xmlRoot, parent):
         assert (xmlRoot.tag == 'IMPLEMENTATION-DATA-TYPE-ELEMENT')
-        (arraySize, arraySizeSemantics, variants) = (None, None, None)
+        arraySize, arraySizeSemantics, variants, subElementsXML = None, None, None, None
         self.push()
         for xmlElem in xmlRoot.findall('./*'):
             if xmlElem.tag == 'SW-DATA-DEF-PROPS':
@@ -216,10 +216,20 @@ class DataTypeParser(ElementParser):
             elif xmlElem.tag == 'ARRAY-SIZE-SEMANTICS':
                 arraySizeSemantics = self.parseTextNode(xmlElem)
             elif xmlElem.tag == 'SUB-ELEMENTS':
-                pass #implement later
+                subElementsXML = xmlElem
             else:
                 self.defaultHandler(xmlElem)
-        elem = autosar.datatype.ImplementationDataTypeElement(self.name, self.category, arraySize, arraySizeSemantics, variants, parent, self.adminData)
+        elem = autosar.datatype.ImplementationDataTypeElement(
+            self.name,
+            category=self.category,
+            arraySize=arraySize,
+            arraySizeSemantics=arraySizeSemantics,
+            parent=parent,
+            adminData=self.adminData,
+            variantProps=variants)
+        if subElementsXML is not None:
+            elem.subElements = self.parseImplementationDataTypeSubElements(
+                subElementsXML, elem)
         self.pop(elem)
         return elem
 

--- a/autosar/parser/datatype_parser.py
+++ b/autosar/parser/datatype_parser.py
@@ -219,14 +219,7 @@ class DataTypeParser(ElementParser):
                 subElementsXML = xmlElem
             else:
                 self.defaultHandler(xmlElem)
-        elem = autosar.datatype.ImplementationDataTypeElement(
-            self.name,
-            category=self.category,
-            arraySize=arraySize,
-            arraySizeSemantics=arraySizeSemantics,
-            parent=parent,
-            adminData=self.adminData,
-            variantProps=variants)
+        elem = autosar.datatype.ImplementationDataTypeElement(self.name, self.category, arraySize, arraySizeSemantics, variants, parent, self.adminData)
         if subElementsXML is not None:
             elem.subElements = self.parseImplementationDataTypeSubElements(
                 subElementsXML, elem)

--- a/autosar/writer/behavior_writer.py
+++ b/autosar/writer/behavior_writer.py
@@ -88,6 +88,11 @@ class XMLBehaviorWriter(ElementWriter):
             for elem in internalBehavior.sharedParameterDataPrototype:
                 lines.extend(self.indent(self._writeParameterDataPrototype(ws, elem),2))
             lines.append(self.indent('</SHARED-PARAMETERS>',1))
+        if isinstance(internalBehavior, autosar.behavior.SwcInternalBehavior) and len(internalBehavior.perInstanceParameterDataPrototype)>0:
+            lines.append(self.indent('<PER-INSTANCE-PARAMETERS>',1))
+            for elem in internalBehavior.perInstanceParameterDataPrototype:
+                lines.extend(self.indent(self._writeParameterDataPrototype(ws, elem),2))
+            lines.append(self.indent('</PER-INSTANCE-PARAMETERS>',1))
         elif isinstance(internalBehavior, autosar.behavior.InternalBehavior) and len(internalBehavior.sharedCalParams)>0:
             lines.append(self.indent('<SHARED-CALPRMS>',1))
             for elem in internalBehavior.sharedCalParams:

--- a/autosar/writer/behavior_writer.py
+++ b/autosar/writer/behavior_writer.py
@@ -83,9 +83,9 @@ class XMLBehaviorWriter(ElementWriter):
             for serviceDependency in internalBehavior.serviceDependencies:
                 lines.extend(self.indent(self._writeServiceDependencyXML(ws, serviceDependency),2))
             lines.append(self.indent('</SERVICE-DEPENDENCYS>',1))
-        if isinstance(internalBehavior, autosar.behavior.SwcInternalBehavior) and len(internalBehavior.parameterDataPrototype)>0:
+        if isinstance(internalBehavior, autosar.behavior.SwcInternalBehavior) and len(internalBehavior.sharedParameterDataPrototype)>0:
             lines.append(self.indent('<SHARED-PARAMETERS>',1))
-            for elem in internalBehavior.parameterDataPrototype:
+            for elem in internalBehavior.sharedParameterDataPrototype:
                 lines.extend(self.indent(self._writeParameterDataPrototype(ws, elem),2))
             lines.append(self.indent('</SHARED-PARAMETERS>',1))
         elif isinstance(internalBehavior, autosar.behavior.InternalBehavior) and len(internalBehavior.sharedCalParams)>0:


### PR DESCRIPTION
Allowing for unlimited nesting for **[TPS_SWCT_01074] Composite Implementation Data Types** according to [AUTOSAR - Software Component Template](https://www.autosar.org/fileadmin/standards/R22-11/CP/AUTOSAR_TPS_SoftwareComponentTemplate.pdf) Subsection 5.2.5.3 - Modeling of Structure using Implementation Data Type, and Subsection 5.2.5.5 - Modeling of Array using Implementation Data Type.

Add parsing of ```PER-INSTANCE-PARAMETERS```