### PR TITLE
Feature/add SW-VALUE-BLOCK-SIZE parsing

### DIFF
--- a/autosar/base.py
+++ b/autosar/base.py
@@ -260,6 +260,8 @@ class SwDataDefPropsConditional:
             valueAxisDataTypeRef = None,
             swRecordLayoutRef = None,
             swCalprmAxisSet = [],
+            swValueBlockSize = None,
+            swValueBlockSizeMults = [],
             parent = None):
 
         self.baseTypeRef = baseTypeRef
@@ -274,6 +276,8 @@ class SwDataDefPropsConditional:
         self.valueAxisDataTypeRef = valueAxisDataTypeRef
         self.swRecordLayoutRef = swRecordLayoutRef
         self.swCalprmAxisSet = swCalprmAxisSet
+        self.swValueBlockSize = swValueBlockSize
+        self.swValueBlockSizeMults = swValueBlockSizeMults
         self.parent = parent
 
     @property

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -247,6 +247,8 @@ class BaseParser:
          compuMethodRef, dataConstraintRef, swPointerTargetPropsXML,
          swImplPolicy, swAddressMethodRef, unitRef, valueAxisDataTypeRef,
          swRecordLayoutRef, swCalprmAxisSet, swValueBlockSize) = (None,) * 13
+        
+        swValueBlockSizeMults = []
         for xmlItem in xmlRoot.findall('./*'):
             if xmlItem.tag == 'BASE-TYPE-REF':
                 baseTypeRef = self.parseTextNode(xmlItem)
@@ -274,6 +276,9 @@ class BaseParser:
                 swCalprmAxisSet = self.parseSwCalprmAxisSet(xmlItem)
             elif xmlItem.tag == 'SW-VALUE-BLOCK-SIZE':
                 swValueBlockSize = self.parseTextNode(xmlItem)
+            elif xmlItem.tag == 'SW-VALUE-BLOCK-SIZE-MULTS':
+                for sizeItem in xmlItem.findall('./*'):
+                    swValueBlockSizeMults.append(self.parseTextNode(sizeItem))
             elif xmlItem.tag == 'ADDITIONAL-NATIVE-TYPE-QUALIFIER':
                 pass #implement later
             elif xmlItem.tag == 'INVALID-VALUE':
@@ -298,7 +303,8 @@ class BaseParser:
             valueAxisDataTypeRef=valueAxisDataTypeRef,
             swRecordLayoutRef=swRecordLayoutRef,
             swCalprmAxisSet=swCalprmAxisSet,
-            swValueBlockSize=swValueBlockSize
+            swValueBlockSize=swValueBlockSize,
+            swValueBlockSizeMults=swValueBlockSizeMults
         )
         if swPointerTargetPropsXML is not None:
             variant.swPointerTargetProps = self.parseSwPointerTargetProps(swPointerTargetPropsXML, variant)

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -275,10 +275,10 @@ class BaseParser:
             elif xmlItem.tag == 'SW-CALPRM-AXIS-SET':
                 swCalprmAxisSet = self.parseSwCalprmAxisSet(xmlItem)
             elif xmlItem.tag == 'SW-VALUE-BLOCK-SIZE':
-                swValueBlockSize = self.parseTextNode(xmlItem)
+                swValueBlockSize = int(self.parseTextNode(xmlItem))
             elif xmlItem.tag == 'SW-VALUE-BLOCK-SIZE-MULTS':
                 for sizeItem in xmlItem.findall('./*'):
-                    swValueBlockSizeMults.append(self.parseTextNode(sizeItem))
+                    swValueBlockSizeMults.append(int(self.parseTextNode(sizeItem)))
             elif xmlItem.tag == 'ADDITIONAL-NATIVE-TYPE-QUALIFIER':
                 pass #implement later
             elif xmlItem.tag == 'INVALID-VALUE':

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -246,7 +246,7 @@ class BaseParser:
         (baseTypeRef, implementationTypeRef, swCalibrationAccess,
          compuMethodRef, dataConstraintRef, swPointerTargetPropsXML,
          swImplPolicy, swAddressMethodRef, unitRef, valueAxisDataTypeRef,
-         swRecordLayoutRef, swCalprmAxisSet) = (None,) * 12
+         swRecordLayoutRef, swCalprmAxisSet, swValueBlockSize) = (None,) * 13
         for xmlItem in xmlRoot.findall('./*'):
             if xmlItem.tag == 'BASE-TYPE-REF':
                 baseTypeRef = self.parseTextNode(xmlItem)
@@ -272,6 +272,8 @@ class BaseParser:
                 swRecordLayoutRef = self.parseTextNode(xmlItem)
             elif xmlItem.tag == 'SW-CALPRM-AXIS-SET':
                 swCalprmAxisSet = self.parseSwCalprmAxisSet(xmlItem)
+            elif xmlItem.tag == 'SW-VALUE-BLOCK-SIZE':
+                swValueBlockSize = self.parseTextNode(xmlItem)
             elif xmlItem.tag == 'ADDITIONAL-NATIVE-TYPE-QUALIFIER':
                 pass #implement later
             elif xmlItem.tag == 'INVALID-VALUE':
@@ -295,7 +297,8 @@ class BaseParser:
             unitRef=unitRef,
             valueAxisDataTypeRef=valueAxisDataTypeRef,
             swRecordLayoutRef=swRecordLayoutRef,
-            swCalprmAxisSet=swCalprmAxisSet
+            swCalprmAxisSet=swCalprmAxisSet,
+            swValueBlockSize=swValueBlockSize
         )
         if swPointerTargetPropsXML is not None:
             variant.swPointerTargetProps = self.parseSwPointerTargetProps(swPointerTargetPropsXML, variant)


### PR DESCRIPTION
This PR adds parsing of the value block size tag. This refers to the dimension of a compound primitive with a VAL_BLK category