### PR TITLE
Initial support for <VARIATION-POINT-PROXYS> in SoftwareComponent entities

### DIFF
--- a/autosar/behavior.py
+++ b/autosar/behavior.py
@@ -1237,13 +1237,14 @@ class SwcInternalBehavior(InternalBehaviorCommon):
     """
     AUTOSAR 4 Internal Behavior
     """
-    def __init__(self,name, componentRef, multipleInstance=False,parent=None):
+    def __init__(self,name, componentRef, multipleInstance=False, parent=None):
         super().__init__(name, componentRef, multipleInstance, parent)
         self.serviceDependencies = [] #list of SwcServiceDependency objects
         self.sharedParameterDataPrototype = [] #list of ParameterDataPrototye objects
         self.perInstanceParameterDataPrototype = []  #list of ParameterDataPrototye objects
         self.dataTypeMappingRefs = [] #list of strings
         self.constantMemories = [] #list of ParameterDataPrototye objects
+        self.variationPointProxies = [] #list of VariationPointProxy objects
 
     def tag(self, version): return "SWC-INTERNAL-BEHAVIOR"
 
@@ -1255,15 +1256,7 @@ class SwcInternalBehavior(InternalBehaviorCommon):
             ref=ref.partition('/')
             name=ref[0]
             foundElem = None
-            for elem in self.sharedParameterDataPrototype:
-                if elem.name == name:
-                    foundElem = elem
-                    break
-            for elem in self.perInstanceParameterDataPrototype:
-                if elem.name == name:
-                    foundElem = elem
-                    break
-            for elem in self.constantMemories:
+            for elem in itertools.chain(self.serviceDependencies, self.sharedParameterDataPrototype, self.perInstanceParameterDataPrototype, self.dataTypeMappingRefs, self.constantMemories, self.variationPointProxies):
                 if elem.name == name:
                     foundElem = elem
                     break
@@ -1449,6 +1442,17 @@ class SwcInternalBehavior(InternalBehaviorCommon):
             self._processModeDependency(event, modeDependency, ws.version)
         self.events.append(event)
         return event
+
+    def createVariationPointProxy(self, name, category, binding_time, condition_access=None, adminData=None):
+        """
+        Creates a new VariationPointProxy object and appends it to the internal variationPointProxies list
+        """
+        self._initSWC()
+        if category == 'CONDITION' and condition_access is None:
+            raise ValueError('condition_access must be provided for category "CONDITION"')
+        variationPointProxy = VariationPointProxy(name, category, binding_time, condition_access, self, adminData)
+        self.variationPointProxies.append(variationPointProxy)
+        return variationPointProxy
 
     def appendDataTypeMappingRef(self, dataTypeMappingRef):
         """
@@ -1929,3 +1933,15 @@ class IncludedDataTypeSet(object):
 
         self.dataTypeRefs = dataTypeRefs
         self.literalPrefix = literalPrefix
+
+class VariationPointProxy(Element):
+    """
+    Represents <VARIATION-POINT-PROXY> (AUTOSAR 4)
+    """
+    def __init__(self, name, category, binding_time, condition_access, parent=None, adminData=None):
+        super().__init__(name, parent, adminData)
+        self.category = category
+        self.binding_time = binding_time
+        self.condition_access = condition_access
+
+    def tag(self, version): return 'VARIATION-POINT-PROXY'

--- a/autosar/parser/behavior_parser.py
+++ b/autosar/parser/behavior_parser.py
@@ -225,6 +225,13 @@ class BehaviorParser(ElementParser):
                                 internalBehavior.constantMemories.append(tmp)
                         else:
                             raise NotImplementedError(xmlChild.tag)
+                elif xmlElem.tag == 'VARIATION-POINT-PROXYS':
+                    for xmlChild in xmlElem.findall('./*'):
+                        if xmlChild.tag == 'VARIATION-POINT-PROXY':
+                            variationPointProxy = self.parseVariationPointProxy(xmlChild, internalBehavior)
+                            internalBehavior.variationPointProxies.append(variationPointProxy)
+                        else:
+                            raise NotImplementedError(xmlChild.tag)
                 else:
                     raise NotImplementedError(xmlElem.tag)
             return internalBehavior
@@ -1181,3 +1188,38 @@ class BehaviorParser(ElementParser):
                 raise RuntimeError(f"Tag '{tag}' is not present in the AUTOSAR specification for the INCLUDED-DATA-TYPE-SET element")
 
         return autosar.behavior.IncludedDataTypeSet(dataTypeRefs=dataTypeRefs, literalPrefix=literalPrefix)
+
+    @parseElementUUID
+    def parseVariationPointProxy(self, xmlRoot, parent):
+        """parses <VARIATION-POINT-PROXY>"""
+
+        assert xmlRoot.tag == 'VARIATION-POINT-PROXY'
+        (name, category, binding_time, condition_access) = (None, None, None, None)
+
+        for item in xmlRoot.findall("./*"):
+            tag = item.tag
+            binding_time = item.get("BINDING-TIME")
+            
+            if tag == "SHORT-NAME":
+                name = self.parseTextNode(item)
+            elif tag == "CATEGORY":
+                category = self.parseTextNode(item)
+            elif tag == "CONDITION-ACCESS":
+                # TODO: Implement
+                condition_access = ''.join(item.itertext())
+            elif tag == "IMPLEMENTATION-DATA-TYPE-REF":
+                # TODO: Implement
+                raise NotImplementedError(tag)
+            elif tag == "POST-BUILD-VALUE-ACCESS-REF":
+                # TODO: Implement
+                raise NotImplementedError(tag)
+            elif tag == "POST-BUILD-VARIANT-CONDITIONS":
+                # TODO: Implement
+                raise NotImplementedError(tag)
+            elif tag == "VALUE-ACCESS":
+                # TODO: Implement
+                raise NotImplementedError(tag)
+            else:
+                raise RuntimeError(f"Tag '{tag}' is not present in the AUTOSAR specification for the VARIATION-POINT-PROXY element")
+
+        return autosar.behavior.VariationPointProxy(name=name, category=category, binding_time=binding_time, condition_access=condition_access, parent=parent)

--- a/autosar/writer/behavior_writer.py
+++ b/autosar/writer/behavior_writer.py
@@ -104,6 +104,11 @@ class XMLBehaviorWriter(ElementWriter):
                 lines.extend(self.indent(self._writeParameterDataPrototype(ws, elem),2))
             lines.append(self.indent('</CONSTANT-MEMORYS>',1))
         lines.append(self.indent('<SUPPORTS-MULTIPLE-INSTANTIATION>%s</SUPPORTS-MULTIPLE-INSTANTIATION>'%('true' if internalBehavior.multipleInstance else 'false'),1))
+        if isinstance(internalBehavior, autosar.behavior.SwcInternalBehavior) and len(internalBehavior.variationPointProxies)>0:
+            lines.append(self.indent('<VARIATION-POINT-PROXYS>',1))
+            for variationPointProxy in internalBehavior.variationPointProxies:
+                lines.extend(self.indent(self._writeVariationPointProxyXML(ws, variationPointProxy),2))
+            lines.append(self.indent('</VARIATION-POINT-PROXYS>',1))
         lines.append('</%s>'%internalBehavior.tag(self.version))
         return lines
 
@@ -1061,4 +1066,17 @@ class CodeBehaviorWriter(ElementWriter):
                 lines.append("'serviceCallPorts': %s"%(params[0]))
             else:
                 lines.append("'serviceCallPorts': [%s]"%(', '.join(params)))
+        return lines
+
+    def _writeVariationPointProxyXML(self, ws, variationPointProxy):
+        lines = []
+        lines.append(f"<{variationPointProxy.tag(self.version)}{f' binding_time=\"{variationPointProxy.binding_time}\"' if variationPointProxy.binding_time is not None else ''}>")
+        lines.append(self.indent('<SHORT-NAME>%s</SHORT-NAME>'%variationPointProxy.name,1))
+        if variationPointProxy.adminData is not None:
+            lines.extend(self.indent(self.writeAdminDataXML(variationPointProxy.adminData),1))
+        if variationPointProxy.category is not None:
+            lines.append(self.indent(f'<CATEGORY>{variationPointProxy.category}</CATEGORY>',1))
+        if variationPointProxy.condition_access is not None:
+            lines.append(self.indent(f'<CONDITION-ACCESS>{variationPointProxy.condition_access}</CONDITION-ACCESS>',1))
+        lines.append('</%s>'%variationPointProxy.tag(self.version))
         return lines


### PR DESCRIPTION
This PR extends the library to support some of the attributes and relations of the Autosar 4 VariationPointProxy entity when inside a SoftwareComponent.

In detail, it adds the support for:
- `binding_time` attribute
- `category`
- `condition_access` (_partial_: the full text content of the `<CONDITION-ACCESS>` tag is captured as is)

Still not supported attributes:
- `implementationDataTypeRef`
- `postBuildValueAccessRef`
- `postBuildVariantConditions`
- `valueAccess`
