### PR TITLE
Support empty Number Nodes

### DIFF
--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -190,6 +190,10 @@ class BaseParser:
 
     def parseNumberNode(self, xmlElem):
         textValue = self.parseTextNode(xmlElem)
+        
+        if textValue is None:
+            return None
+        
         retval = None
         try:
             retval = int(textValue)


### PR DESCRIPTION
Number nodes, such as <UPPER-LIMIT> or <LOWER-LIMIT> can be declared empty. In such case, this PR causes a fallback on a None value, which was already supported.