### PR TITLE
Restructure Parser type hierarchy to support ConstantParser access from all other Autosar Entity Parsers

### DIFF
--- a/autosar/parser/behavior_parser.py
+++ b/autosar/parser/behavior_parser.py
@@ -1,11 +1,9 @@
 import autosar.behavior, autosar.element
-from autosar.parser.parser_base import ElementParser, parseElementUUID
-from autosar.parser.constant_parser import ConstantParser
+from autosar.parser.parser_base import EntityParser, parseElementUUID
 
-class BehaviorParser(ElementParser):
+class BehaviorParser(EntityParser):
     def __init__(self,version=3.0):
         super().__init__(version)
-        self.constantParser = ConstantParser(version)
 
     def getSupportedTags(self):
         if (self.version >=3.0) and (self.version < 4.0):

--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -2,8 +2,7 @@ import sys
 from autosar.base import splitRef, hasAdminData, parseAdminDataNode
 import autosar.component
 from autosar.parser.behavior_parser import BehaviorParser
-from autosar.parser.parser_base import ElementParser, parseElementUUID
-from autosar.parser.constant_parser import ConstantParser
+from autosar.parser.parser_base import EntityParser, parseElementUUID
 
 def _getDataElemNameFromComSpec(xmlElem,portInterfaceRef):
     if xmlElem.find('./DATA-ELEMENT-REF') is not None:
@@ -46,7 +45,7 @@ def _getVariableNameFromComSpec(xmlElem,portInterfaceRef):
             return name
     return None
 
-class ComponentTypeParser(ElementParser):
+class ComponentTypeParser(EntityParser):
     """
     ComponentType parser
     """
@@ -55,7 +54,6 @@ class ComponentTypeParser(ElementParser):
         super().__init__(version)
         if self.version >=4.0:
             self.behavior_parser = BehaviorParser(version)
-            self.constant_parser = ConstantParser(version)
 
         if self.version >= 3.0 and self.version < 4.0:
             self.switcher = { 'APPLICATION-SOFTWARE-COMPONENT-TYPE': self.parseSoftwareComponent,
@@ -438,7 +436,7 @@ class ComponentTypeParser(ElementParser):
             if xmlChild.tag == 'CONSTANT-REFERENCE':
                 initValueRef = self.parseTextNode(xmlChild.find('./CONSTANT-REF'))
             else:
-                values = self.constant_parser.parseValueV4(xmlElem, None)
+                values = self.constantParser.parseValueV4(xmlElem, None)
                 if len(values) != 1:
                     raise ValueError('{0} cannot cannot contain multiple elements'.format(xmlElem.tag))
                 initValue = values[0]

--- a/autosar/parser/constant_parser.py
+++ b/autosar/parser/constant_parser.py
@@ -123,7 +123,17 @@ class ConstantParser(ElementParser):
             elif xmlElem.tag == 'APPLICATION-VALUE-SPECIFICATION':
                 result.append(self._parseApplicationValueSpecification(xmlElem, parent))
             else:
-                raise NotImplementedError(xmlElem.tag)
+                #TODO: Implement remaining VALUE-SPECIFICATION
+                warning_cause = (
+                    f" (parent name: {parent.name})"
+                    if parent is not None 
+                        and hasattr(parent, 'name') 
+                        and parent.name is not None 
+                        and len(str(parent.name)) > 0 
+                    else ''
+                )
+                print(f"WARNING: <{xmlElem.tag}> is not currently supported and will be considered as 0{warning_cause}")
+                result.append(autosar.constant.NumericalValue(None, 0, parent))
         return result
 
     def _parseTextValueSpecification(self, xmlValue, parent):

--- a/autosar/parser/constant_parser.py
+++ b/autosar/parser/constant_parser.py
@@ -123,17 +123,7 @@ class ConstantParser(ElementParser):
             elif xmlElem.tag == 'APPLICATION-VALUE-SPECIFICATION':
                 result.append(self._parseApplicationValueSpecification(xmlElem, parent))
             else:
-                #TODO: Implement remaining VALUE-SPECIFICATION
-                warning_cause = (
-                    f" (parent name: {parent.name})"
-                    if parent is not None 
-                        and hasattr(parent, 'name') 
-                        and parent.name is not None 
-                        and len(str(parent.name)) > 0 
-                    else ''
-                )
-                print(f"WARNING: <{xmlElem.tag}> is not currently supported and will be considered as 0{warning_cause}")
-                result.append(autosar.constant.NumericalValue(None, 0, parent))
+                raise NotImplementedError(xmlElem.tag)
         return result
 
     def _parseTextValueSpecification(self, xmlValue, parent):

--- a/autosar/parser/datatype_parser.py
+++ b/autosar/parser/datatype_parser.py
@@ -1,8 +1,8 @@
 import sys
-from autosar.parser.parser_base import ElementParser, parseElementUUID
+from autosar.parser.parser_base import EntityParser, parseElementUUID
 import autosar.datatype
 
-class DataTypeParser(ElementParser):
+class DataTypeParser(EntityParser):
     def __init__(self,version=3.0):
         super().__init__(version)
 
@@ -414,7 +414,7 @@ class DataTypeParser(ElementParser):
                 return literal
         raise ValueError(f"Invalid value for ArraySizeHandling field: '{text}'")
 
-class DataTypeSemanticsParser(ElementParser):
+class DataTypeSemanticsParser(EntityParser):
     def __init__(self,version=3.0):
         super().__init__(version)
 
@@ -535,7 +535,7 @@ class DataTypeSemanticsParser(ElementParser):
         denominator = self.parseNumberNode(denXml[0])
         return offset, numerator, denominator
 
-class DataTypeUnitsParser(ElementParser):
+class DataTypeUnitsParser(EntityParser):
     def __init__(self,version=3.0):
         super().__init__(version)
 

--- a/autosar/parser/ecu_configuration_parser.py
+++ b/autosar/parser/ecu_configuration_parser.py
@@ -1,7 +1,7 @@
 import autosar.ecuc
-from autosar.parser.parser_base import ElementParser, parseElementUUID
+from autosar.parser.parser_base import EntityParser, parseElementUUID
 
-class EcuConfigurationParser(ElementParser):
+class EcuConfigurationParser(EntityParser):
     """
     Ecu Configuration parser
     """

--- a/autosar/parser/mode_parser.py
+++ b/autosar/parser/mode_parser.py
@@ -1,8 +1,8 @@
 import sys
-from autosar.parser.parser_base import ElementParser, parseElementUUID
+from autosar.parser.parser_base import EntityParser, parseElementUUID
 import autosar.datatype
 
-class ModeDeclarationParser(ElementParser):
+class ModeDeclarationParser(EntityParser):
     def __init__(self,version=3):
         self.version=version
 

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -515,13 +515,10 @@ class EntityParser(ElementParser, metaclass=abc.ABCMeta):
                     if xmlChild.tag == 'CONSTANT-REFERENCE':
                         specializedAutosarDataPrototype.initValueRef = self.parseTextNode(xmlChild.find('./CONSTANT-REF'))
                     else:
-                        try:
-                            values = self.constantParser.parseValueV4(xmlElem, specializedAutosarDataPrototype)
-                            if len(values) != 1:
-                                raise ValueError('{0} cannot cannot contain multiple elements'.format(xmlElem.tag))
-                            specializedAutosarDataPrototype.initValue = values[0]
-                        except NotImplementedError as e:
-                            print(f"WARNING: <{e.args[0]}> is not currently supported and will be considered as 0 (defined in entity named '{self.name}')")
+                        values = self.constantParser.parseValueV4(xmlElem, specializedAutosarDataPrototype)
+                        if len(values) != 1:
+                            raise ValueError('{0} cannot cannot contain multiple elements'.format(xmlElem.tag))
+                        specializedAutosarDataPrototype.initValue = values[0]
 
             if (props_variants is not None) and len(props_variants) > 0:
                 specializedAutosarDataPrototype.setProps(props_variants[0])

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -521,7 +521,7 @@ class EntityParser(ElementParser, metaclass=abc.ABCMeta):
                                 raise ValueError('{0} cannot cannot contain multiple elements'.format(xmlElem.tag))
                             specializedAutosarDataPrototype.initValue = values[0]
                         except NotImplementedError as e:
-                            print(f"WARNING: <{e.args[0]}> is not currently supported and will be considered as 0 (defined in entity named '{self.name}')")
+                            print(f"WARNING: <{e.args[0]}> (defined in entity named '{self.name}') is not currently supported and will be ignored")
 
             if (props_variants is not None) and len(props_variants) > 0:
                 specializedAutosarDataPrototype.setProps(props_variants[0])

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -515,10 +515,13 @@ class EntityParser(ElementParser, metaclass=abc.ABCMeta):
                     if xmlChild.tag == 'CONSTANT-REFERENCE':
                         specializedAutosarDataPrototype.initValueRef = self.parseTextNode(xmlChild.find('./CONSTANT-REF'))
                     else:
-                        values = self.constantParser.parseValueV4(xmlElem, specializedAutosarDataPrototype)
-                        if len(values) != 1:
-                            raise ValueError('{0} cannot cannot contain multiple elements'.format(xmlElem.tag))
-                        specializedAutosarDataPrototype.initValue = values[0]
+                        try:
+                            values = self.constantParser.parseValueV4(xmlElem, specializedAutosarDataPrototype)
+                            if len(values) != 1:
+                                raise ValueError('{0} cannot cannot contain multiple elements'.format(xmlElem.tag))
+                            specializedAutosarDataPrototype.initValue = values[0]
+                        except NotImplementedError as e:
+                            print(f"WARNING: <{e.args[0]}> is not currently supported and will be considered as 0 (defined in entity named '{self.name}')")
 
             if (props_variants is not None) and len(props_variants) > 0:
                 specializedAutosarDataPrototype.setProps(props_variants[0])

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -488,22 +488,16 @@ class EntityParser(ElementParser, metaclass=abc.ABCMeta):
         dataPrototypeRole = autosar.element.AutosarDataPrototype.TAG_TO_ROLE_MAP.get(xmlRoot.tag)
         if dataPrototypeRole is None:
             raise NotImplementedError(xmlRoot.tag)
-        (typeRef, props_variants, isQueued, initValue, initValueRef) = (None, None, False, None, None)
+        (typeRef, props_variants, isQueued) = (None, None, False)
         self.push()
+        initValueElement = None
         for xmlElem in xmlRoot.findall('./*'):
             if xmlElem.tag == 'TYPE-TREF':
                 typeRef = self.parseTextNode(xmlElem)
             elif xmlElem.tag == 'SW-DATA-DEF-PROPS':
                 props_variants = self.parseSwDataDefProps(xmlElem)
             elif xmlElem.tag == 'INIT-VALUE':
-                for xmlChild in xmlElem.findall('./*'):
-                    if xmlChild.tag == 'CONSTANT-REFERENCE':
-                        initValueRef = self.parseTextNode(xmlChild.find('./CONSTANT-REF'))
-                    else:
-                        values = self.constantParser.parseValueV4(xmlElem, None)
-                        if len(values) != 1:
-                            raise ValueError('{0} cannot cannot contain multiple elements'.format(xmlElem.tag))
-                        initValue = values[0]
+                initValueElement = xmlElem
             else:
                 self.defaultHandler(xmlElem)
         if (self.name is not None) and (typeRef is not None):
@@ -512,12 +506,20 @@ class EntityParser(ElementParser, metaclass=abc.ABCMeta):
                 self.name,
                 typeRef,
                 isQueued,
-                initValue = initValue,
-                initValueRef = initValueRef,
                 category = self.category,
                 parent = parent,
                 adminData = self.adminData
             )
+            if initValueElement is not None:
+                for xmlChild in initValueElement.findall('./*'):
+                    if xmlChild.tag == 'CONSTANT-REFERENCE':
+                        specializedAutosarDataPrototype.initValueRef = self.parseTextNode(xmlChild.find('./CONSTANT-REF'))
+                    else:
+                        values = self.constantParser.parseValueV4(xmlElem, specializedAutosarDataPrototype)
+                        if len(values) != 1:
+                            raise ValueError('{0} cannot cannot contain multiple elements'.format(xmlElem.tag))
+                        specializedAutosarDataPrototype.initValue = values[0]
+
             if (props_variants is not None) and len(props_variants) > 0:
                 specializedAutosarDataPrototype.setProps(props_variants[0])
             self.pop(specializedAutosarDataPrototype)

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -521,7 +521,7 @@ class EntityParser(ElementParser, metaclass=abc.ABCMeta):
                                 raise ValueError('{0} cannot cannot contain multiple elements'.format(xmlElem.tag))
                             specializedAutosarDataPrototype.initValue = values[0]
                         except NotImplementedError as e:
-                            print(f"WARNING: <{e.args[0]}> (defined in entity named '{self.name}') is not currently supported and will be ignored")
+                            print(f"WARNING: <{e.args[0]}> is not currently supported and will be considered as 0 (defined in entity named '{self.name}')")
 
             if (props_variants is not None) and len(props_variants) > 0:
                 specializedAutosarDataPrototype.setProps(props_variants[0])

--- a/autosar/parser/portinterface_parser.py
+++ b/autosar/parser/portinterface_parser.py
@@ -3,9 +3,9 @@ import autosar.portinterface
 import autosar.base
 import autosar.element
 import autosar.mode
-from autosar.parser.parser_base import ElementParser, parseElementUUID
+from autosar.parser.parser_base import EntityParser, parseElementUUID
 
-class PortInterfacePackageParser(ElementParser):
+class PortInterfacePackageParser(EntityParser):
     def __init__(self, version=3.0):
         super().__init__(version)
 
@@ -406,7 +406,7 @@ class PortInterfacePackageParser(ElementParser):
             return None
 
 
-class SoftwareAddressMethodParser(ElementParser):
+class SoftwareAddressMethodParser(EntityParser):
     def __init__(self,version=3.0):
         self.version=version
 

--- a/autosar/parser/signal_parser.py
+++ b/autosar/parser/signal_parser.py
@@ -1,8 +1,8 @@
 from autosar.base import parseXMLFile,splitRef,parseTextNode,parseIntNode
 from autosar.signal import *
-from autosar.parser.parser_base import ElementParser, parseElementUUID
+from autosar.parser.parser_base import EntityParser, parseElementUUID
 
-class SignalParser(ElementParser):
+class SignalParser(EntityParser):
     def __init__(self,version=3):
         self.version=version
 

--- a/autosar/parser/swc_implementation_parser.py
+++ b/autosar/parser/swc_implementation_parser.py
@@ -4,9 +4,9 @@ Implements the class SwcImplementationParser
 import sys
 from autosar.base import splitRef, hasAdminData, parseAdminDataNode
 import autosar.component
-from autosar.parser.parser_base import ElementParser, parseElementUUID
+from autosar.parser.parser_base import EntityParser, parseElementUUID
 
-class SwcImplementationParser(ElementParser):
+class SwcImplementationParser(EntityParser):
     """
     ComponentType parser
     """

--- a/autosar/parser/system_parser.py
+++ b/autosar/parser/system_parser.py
@@ -1,8 +1,8 @@
 from autosar.base import parseXMLFile,splitRef,parseTextNode,parseIntNode,hasAdminData,parseAdminDataNode
 from autosar.system import *
-from autosar.parser.parser_base import ElementParser, parseElementUUID
+from autosar.parser.parser_base import EntityParser, parseElementUUID
 
-class SystemParser(ElementParser):
+class SystemParser(EntityParser):
     def __init__(self,version=3.0):
         super().__init__(version)
 


### PR DESCRIPTION
This pull request restructures the Parser type hierarchy to allow access to the ConstantParser from all other Autosar Entity Parsers. This change ensures that the ConstantParser can be used by other parsers to parse and handle constant values in the code.

The hierarchy becomes:

1. BaseParser (handles any common entity fields and has basic parsing functionalities)
2. ElementPerser (targets a subset of ARXML elements)
3. (branches)
    a. ConstantParser (target ARXML constants)
    b. EntityPerser (target AUTOSAR entities) - exposes a self.constantParser to allow for parsing constants while parsing entities; -> all Entity-specific parsers, e.g., behavior, component, etc., inherits from here
        
