### PR TITLE
Symbol accessed before definition

### DIFF
--- a/autosar/parser/behavior_parser.py
+++ b/autosar/parser/behavior_parser.py
@@ -331,6 +331,9 @@ class BehaviorParser(EntityParser):
                     pass #implement later
                 else:
                     self.defaultHandler(xmlElem)
+        if name is None:
+            handleValueError('SHORT-NAME is required for RunnableEntity')
+            return None
         runnableEntity = autosar.behavior.RunnableEntity(name, canBeInvokedConcurrently, symbol, parent)
         if minStartInterval is not None:
             runnableEntity.minStartInterval = float(1000 * minStartInterval)

--- a/autosar/parser/behavior_parser.py
+++ b/autosar/parser/behavior_parser.py
@@ -247,6 +247,8 @@ class BehaviorParser(EntityParser):
 
     @parseElementUUID
     def parseRunnableEntity(self, xmlRoot, parent):
+        name = None
+        symbol = None
         xmlDataReceivePoints = None
         xmlDataSendPoints = None
         xmlServerCallPoints = None


### PR DESCRIPTION
Parsing `<RUNNABLE-ENTITY>`s that do not specify any `<SYMBOL>` lead to accessing the `symbol` variable before its definition