### PR TITLE
Bugfix/crash_in_value_builder_for_unbound_error

### DIFF
--- a/autosar/builder.py
+++ b/autosar/builder.py
@@ -26,6 +26,7 @@ class ValueBuilder:
         if isinstance(dataType, (autosar.datatype.ImplementationDataType, autosar.datatype.ApplicationPrimitiveDataType)):
             value = None
             dataConstraint = None
+            variantProps = None
             if isinstance(dataType, autosar.datatype.ImplementationDataType):
                 variantProps = dataType.variantProps[0]
             if variantProps is not None:


### PR DESCRIPTION
This fix comes from the commit SHA `1c5aac13693678a9234910aa8b1f66bb6345c372` from `cogu/autosar`