### PR TITLE
Extend parsing to better support Extracts

### DIFF
--- a/autosar/component.py
+++ b/autosar/component.py
@@ -626,12 +626,13 @@ class AssemblyConnector(Element):
     """
     <ASSEMBLY-CONNECTOR-PROTOTYPE>
     """
-    def __init__(self,name,providerInstanceRef,requesterInstanceRef,parent=None):
+    def __init__(self,name,providerInstanceRef,requesterInstanceRef,mappingRef,parent=None):
         assert(isinstance(providerInstanceRef,ProviderInstanceRef))
         assert(isinstance(requesterInstanceRef,RequesterInstanceRef))
         super().__init__(name, parent)
         self.providerInstanceRef=providerInstanceRef
         self.requesterInstanceRef=requesterInstanceRef
+        self.mappingRef=mappingRef
     def asdict(self):
         return {'type': self.__class__.__name__,'providerInstanceRef':self.providerInstanceRef.asdict(),'requesterInstanceRef':self.requesterInstanceRef.asdict()}
 

--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -362,7 +362,7 @@ class ComponentTypeParser(EntityParser):
             elif xmlChild.tag == 'MAPPING-REF':
                 mappingRef = self.parseTextNode(xmlChild)
             else:
-                handleNotImplementedError(xmlChild.tag)
+                self.defaultHandler(xmlChild)
         if providerComponentRef is None:
             raise RuntimeError('PROVIDER-IREF/CONTEXT-COMPONENT-REF is missing: item=%s'%name)
         if providerComponentRef is None:

--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -348,6 +348,7 @@ class ComponentTypeParser(EntityParser):
         parses <ASSEMBLY-SW-CONNECTOR>
         """
         assert xmlRoot.tag == 'ASSEMBLY-SW-CONNECTOR'
+        mappingRef = None
         name=self.parseTextNode(xmlRoot.find('SHORT-NAME'))
         for xmlChild in xmlRoot.findall('./*'):
             if xmlChild.tag == 'SHORT-NAME':
@@ -358,6 +359,8 @@ class ComponentTypeParser(EntityParser):
             elif xmlChild.tag == 'REQUESTER-IREF':
                 requesterComponentRef=self.parseTextNode(xmlChild.find('./CONTEXT-COMPONENT-REF'))
                 requesterPortRef=self.parseTextNode(xmlChild.find('./TARGET-R-PORT-REF'))
+            elif xmlChild.tag == 'MAPPING-REF':
+                mappingRef = self.parseTextNode(xmlChild)
             else:
                 handleNotImplementedError(xmlChild.tag)
         if providerComponentRef is None:
@@ -369,7 +372,12 @@ class ComponentTypeParser(EntityParser):
         if requesterPortRef is None:
             raise RuntimeError('REQUESTER-IREF/TARGET-R-PORT-REF is missing: item=%s'%name)
 
-        return autosar.component.AssemblyConnector(name, autosar.component.ProviderInstanceRef(providerComponentRef,providerPortRef), autosar.component.RequesterInstanceRef(requesterComponentRef,requesterPortRef), parent=parent)
+        return autosar.component.AssemblyConnector(
+            name,
+            autosar.component.ProviderInstanceRef(providerComponentRef,providerPortRef),
+            autosar.component.RequesterInstanceRef(requesterComponentRef,requesterPortRef),
+            mappingRef,
+            parent=parent)
 
     @parseElementUUID
     def _parseDelegationSwConnector(self, xmlRoot, parent = None):

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -113,6 +113,8 @@ class BaseParser:
             self.common[-1].displayFormat = None
         elif xmlElem.tag == 'ANNOTATION':
             pass #implement later
+        elif xmlElem.tag == 'ANNOTATIONS':
+            pass #implement later
         elif xmlElem.tag == 'INTRODUCTION':
             pass #implement later
         else:

--- a/autosar/parser/parser_base.py
+++ b/autosar/parser/parser_base.py
@@ -521,8 +521,6 @@ class EntityParser(ElementParser, metaclass=abc.ABCMeta):
             self.pop()
             if self.name is None:
                 raise RuntimeError(f'Error in TAG {xmlRoot.tag}: SHORT-NAME and TYPE-TREF must not be None')
-            else:
-                raise RuntimeError(f'Error in TAG {xmlRoot.tag}: TYPE-TREF not defined for element with SHORT-NAME "{self.name}"')
 
     def _parseAr4InitValue(self, xmlElem):
         (initValue, initValueRef) = (None, None)

--- a/autosar/parser/system_parser.py
+++ b/autosar/parser/system_parser.py
@@ -129,14 +129,16 @@ class SystemParser(EntityParser):
     def parseRootSwCompositionPrototype(self,xmlRoot,system):
         """parses <ROOT-SW-COMPOSITION-PROTOTYPE>"""
         assert(xmlRoot.tag=='ROOT-SW-COMPOSITION-PROTOTYPE')
-        compositionTref = None
+        compositionTref, flatMapRef = None, None
         self.push()
         for xmlElem in xmlRoot.findall('./*'):
             if xmlElem.tag=='SOFTWARE-COMPOSITION-TREF':
                 compositionTref = self.parseTextNode(xmlElem)
+            elif xmlElem.tag=='FLAT-MAP-REF':
+                flatMapRef = self.parseTextNode(xmlElem)
             else:
                 self.defaultHandler(xmlElem)
-        obj = RootSwCompositionPrototype(self.name, compositionTref, self.adminData, self.category, system)
+        obj = RootSwCompositionPrototype(self.name, compositionTref, flatMapRef, self.adminData, self.category, system)
         self.pop(obj)
         return obj
 

--- a/autosar/system.py
+++ b/autosar/system.py
@@ -100,6 +100,7 @@ class RootSwCompositionPrototype(Element):
     """
     def tag(self, version=None): return "ROOT-SW-COMPOSITION-PROTOTYPE"
 
-    def __init__(self, name, softwareCompositionTref, adminData=None, category=None, parent=None):
+    def __init__(self, name, softwareCompositionTref, flatMapRef, adminData=None, category=None, parent=None):
         super().__init__(name, parent, adminData, category)
         self.softwareCompositionTref = softwareCompositionTref
+        self.flatMapRef = flatMapRef


### PR DESCRIPTION
This PR introduces
- in ASSEMBLY-CONNECTOR-PROTOTYPE: MAPPING-REF
- ASSEMBLY-CONNECTOR-PROTOTYPE fallback parsing on defaultHandler
- ANNOTATIONS to defaultHandler
- in ROOT-SW-COMPOSITION-PROTOTYPE: FLAT-MAP-REF