### PR TITLE
Relax Assembly Connector Parsing and Support RUNS-INSIDES

### DIFF
--- a/autosar/behavior.py
+++ b/autosar/behavior.py
@@ -260,6 +260,7 @@ class RunnableEntity(Element):
         self.parameterAccessPoints = [] #AUTOSAR4 only
         self.activationReasons = [] #AUTOSAR4 only
         self.externalTriggeringPoints = [] #AUTOSAR4 only
+        self.runsInsidesExclusiveAreas = [] #AUTOSAR4 only #type: List[Union[ExclusiveAreaRefConditional, str]]
 
     def tag(self,version=None):
         return 'RUNNABLE-ENTITY'
@@ -2311,3 +2312,14 @@ class VariationPoint:
         self.bindingTime = bindingTime
 
     def tag(self, version): return 'VARIATION-POINT'
+
+class ExclusiveAreaRefConditional:
+    """
+    Represents <EXCLUSIVE-AREA-REF-CONDITIONAL> (AUTOSAR 4)
+    """
+
+    def __init__(self, exclusiveAreaRef, variationPoint):
+        self.exclusiveAreaRef = exclusiveAreaRef
+        self.variationPoint = variationPoint
+
+    def tag(self, version): return 'EXCLUSIVE-AREA-REF-CONDITIONAL'

--- a/autosar/parser/behavior_parser.py
+++ b/autosar/parser/behavior_parser.py
@@ -1588,6 +1588,7 @@ class BehaviorParser(EntityParser):
                 raise RuntimeError(f"Tag '{tag}' is not present in the AUTOSAR specification for the VARIATION-POINT-PROXY element")
 
         return autosar.behavior.VariationPointProxy(name=name, category=category, binding_time=binding_time, condition_access=condition_access, parent=parent)
+
     def parseExclusiveAreaRefConditional(self, xmlRoot, parent):
         """parses <EXCLUSIVE-AREA-REF-CONDITIONAL>"""
         assert(xmlRoot.tag == 'EXCLUSIVE-AREA-REF-CONDITIONAL')

--- a/autosar/parser/behavior_parser.py
+++ b/autosar/parser/behavior_parser.py
@@ -286,6 +286,8 @@ class BehaviorParser(EntityParser):
         minStartInterval = None
         xmlActivationReasons = None
         xmlExternalTriggeringPoints = None
+        xmlRunsInsides = None
+        xmlRunsInsideExclusiveAreaRefs = None
 
         xmlDataReadAccess = None
         xmlDataWriteAccess = None
@@ -355,7 +357,9 @@ class BehaviorParser(EntityParser):
                 elif xmlElem.tag == 'EXTERNAL-TRIGGERING-POINTS':
                     xmlExternalTriggeringPoints = xmlElem
                 elif xmlElem.tag == 'RUNS-INSIDE-EXCLUSIVE-AREA-REFS':
-                    pass #implement later
+                    xmlRunsInsideExclusiveAreaRefs = xmlElem
+                elif xmlElem.tag == 'RUNS-INSIDES':
+                    xmlRunsInsides = xmlElem
                 else:
                     self.defaultHandler(xmlElem)
         if name is None:
@@ -486,7 +490,24 @@ class BehaviorParser(EntityParser):
                         runnableEntity.externalTriggeringPoints.append(externalTriggeringPoint)
                 else:
                     handleNotImplementedError(xmlElem.tag)
-        
+
+        if xmlRunsInsideExclusiveAreaRefs is not None:
+            for xmlElem in xmlRunsInsideExclusiveAreaRefs.findall('./*'):
+                if xmlElem.tag == 'RUNS-INSIDE-EXCLUSIVE-AREA-REF':
+                    runnableEntity.runsInsidesExclusiveAreas.append(self.parseTextNode(xmlElem))
+                else:
+                    handleNotImplementedError(xmlElem.tag)
+
+
+        if xmlRunsInsides is not None:
+            for xmlElem in xmlRunsInsides.findall('./*'):
+                if xmlElem.tag == 'EXCLUSIVE-AREA-REF-CONDITIONAL':
+                    exclusiveAreaRefConditional = self.parseExclusiveAreaRefConditional(xmlElem, runnableEntity)
+                    if exclusiveAreaRefConditional is not None:
+                        runnableEntity.runsInsidesExclusiveAreas.append(exclusiveAreaRefConditional)
+                else:
+                    handleNotImplementedError(xmlElem.tag)
+
         if runnableEntity is not None:
             runnableEntity.adminData = adminData
         self.pop()
@@ -1567,3 +1588,16 @@ class BehaviorParser(EntityParser):
                 raise RuntimeError(f"Tag '{tag}' is not present in the AUTOSAR specification for the VARIATION-POINT-PROXY element")
 
         return autosar.behavior.VariationPointProxy(name=name, category=category, binding_time=binding_time, condition_access=condition_access, parent=parent)
+    def parseExclusiveAreaRefConditional(self, xmlRoot, parent):
+        """parses <EXCLUSIVE-AREA-REF-CONDITIONAL>"""
+        assert(xmlRoot.tag == 'EXCLUSIVE-AREA-REF-CONDITIONAL')
+        exclusiveAreaRef, variationPoint = None, None
+        for xmlElem in xmlRoot.findall('./*'):
+            if xmlElem.tag == 'EXCLUSIVE-AREA-REF':
+                exclusiveAreaRef = self.parseTextNode(xmlElem)
+            elif xmlElem.tag == 'VARIATION-POINT':
+                variationPoint = self.parseVariationPoint(xmlElem)
+            else:
+                handleNotImplementedError(xmlElem.tag)
+
+        return autosar.behavior.ExclusiveAreaRefConditional(exclusiveAreaRef, variationPoint)

--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -366,7 +366,7 @@ class ComponentTypeParser(EntityParser):
         if providerComponentRef is None:
             #raise RuntimeError('PROVIDER-IREF/CONTEXT-COMPONENT-REF is missing: item=%s'%name)
             pass # NOTE: in order to support partially defined ARXML files, the exception is suppressed and the user is expected to discard incomplete connectors
-        if providerComponentRef is None:
+        if providerPortRef is None:
             #raise RuntimeError('PROVIDER-IREF/TARGET-P-PORT-REF is missing: item=%s'%name)
             pass # NOTE: in order to support partially defined ARXML files, the exception is suppressed and the user is expected to discard incomplete connectors
         if requesterComponentRef is None:

--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -364,13 +364,17 @@ class ComponentTypeParser(EntityParser):
             else:
                 self.defaultHandler(xmlChild)
         if providerComponentRef is None:
-            raise RuntimeError('PROVIDER-IREF/CONTEXT-COMPONENT-REF is missing: item=%s'%name)
+            #raise RuntimeError('PROVIDER-IREF/CONTEXT-COMPONENT-REF is missing: item=%s'%name)
+            pass # NOTE: in order to support partially defined ARXML files, the exception is suppressed and the user is expected to discard incomplete connectors
         if providerComponentRef is None:
-            raise RuntimeError('PROVIDER-IREF/TARGET-P-PORT-REF is missing: item=%s'%name)
+            #raise RuntimeError('PROVIDER-IREF/TARGET-P-PORT-REF is missing: item=%s'%name)
+            pass # NOTE: in order to support partially defined ARXML files, the exception is suppressed and the user is expected to discard incomplete connectors
         if requesterComponentRef is None:
-            raise RuntimeError('REQUESTER-IREF/CONTEXT-COMPONENT-REF is missing: item=%s'%name)
+            #raise RuntimeError('REQUESTER-IREF/CONTEXT-COMPONENT-REF is missing: item=%s'%name)
+            pass # NOTE: in order to support partially defined ARXML files, the exception is suppressed and the user is expected to discard incomplete connectors
         if requesterPortRef is None:
-            raise RuntimeError('REQUESTER-IREF/TARGET-R-PORT-REF is missing: item=%s'%name)
+            #raise RuntimeError('REQUESTER-IREF/TARGET-R-PORT-REF is missing: item=%s'%name)
+            pass # NOTE: in order to support partially defined ARXML files, the exception is suppressed and the user is expected to discard incomplete connectors
 
         return autosar.component.AssemblyConnector(
             name,


### PR DESCRIPTION
This PR **allows** the incomplete definition of an ASSEMBLY-SW-CONNECTOR + parses the RUNS-INSIDES (and variants) in RUNNABLE-ENTITY