### PR TITLE
Feature/Support <USES-END-TO-END-PROTECTION> and <ENABLE-UPDATE> tags

### DIFF
--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -174,15 +174,26 @@ class ComponentTypeParser(EntityParser):
         elif xmlItem.tag == 'UNQUEUED-RECEIVER-COM-SPEC' or xmlItem.tag == 'NONQUEUED-RECEIVER-COM-SPEC':
             dataElemName = _getDataElemNameFromComSpec(xmlItem,portInterfaceRef)
             comspec = autosar.port.DataElementComSpec(dataElemName)
-            if xmlItem.find('./ALIVE-TIMEOUT') is not None:
-                comspec.aliveTimeout = self.parseTextNode(xmlItem.find('./ALIVE-TIMEOUT'))
+            aliveTimeout = xmlItem.find('./ALIVE-TIMEOUT')
+            if aliveTimeout != None:
+                comspec.aliveTimeout = self.parseTextNode(aliveTimeout)
             if self.version >= 4.0:
                 xmlElem = xmlItem.find('./INIT-VALUE')
                 if xmlElem != None:
                     comspec.initValue, comspec.initValueRef = self._parseAr4InitValue(xmlElem)
             else:
-                if xmlItem.find('./INIT-VALUE-REF') != None:
-                    comspec.initValueRef = self.parseTextNode(xmlItem.find('./INIT-VALUE-REF'))
+                initValueRef = xmlItem.find('./INIT-VALUE-REF')
+                if initValueRef is not None:
+                    comspec.initValueRef = self.parseTextNode(initValueRef)
+
+            enableUpdate = xmlItem.find('./ENABLE-UPDATE')
+            if enableUpdate != None:
+                comspec.enableUpdate = True if self.parseTextNode(enableUpdate)=='true' else False
+
+            usesEndToEndProtection = xmlItem.find('./USES-END-TO-END-PROTECTION')
+            if usesEndToEndProtection != None:
+                comspec.usesEndToEndProtection = True if self.parseTextNode(usesEndToEndProtection)=='true' else False
+
             port._comspec.required.append(comspec)
         elif xmlItem.tag == 'QUEUED-RECEIVER-COM-SPEC':
             dataElemName = _getDataElemNameFromComSpec(xmlItem,portInterfaceRef)

--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -188,11 +188,11 @@ class ComponentTypeParser(EntityParser):
 
             enableUpdate = xmlItem.find('./ENABLE-UPDATE')
             if enableUpdate != None:
-                comspec.enableUpdate = True if self.parseTextNode(enableUpdate)=='true' else False
+                comspec.enableUpdate = self.parseBooleanNode(enableUpdate)
 
             usesEndToEndProtection = xmlItem.find('./USES-END-TO-END-PROTECTION')
             if usesEndToEndProtection != None:
-                comspec.usesEndToEndProtection = True if self.parseTextNode(usesEndToEndProtection)=='true' else False
+                comspec.usesEndToEndProtection = self.parseBooleanNode(usesEndToEndProtection)
 
             port._comspec.required.append(comspec)
         elif xmlItem.tag == 'QUEUED-RECEIVER-COM-SPEC':
@@ -234,15 +234,15 @@ class ComponentTypeParser(EntityParser):
 
             enableUpdate = xmlItem.find('./ENABLE-UPDATE')
             if enableUpdate != None:
-                comspec.enableUpdate = True if self.parseTextNode(enableUpdate)=='true' else False
+                comspec.enableUpdate = self.parseBooleanNode(enableUpdate)
 
             canInvalidate = xmlItem.find('./CAN-INVALIDATE')
             if canInvalidate != None:
-                comspec.canInvalidate = True if self.parseTextNode(canInvalidate)=='true' else False
+                comspec.canInvalidate = self.parseBooleanNode(canInvalidate)
 
             usesEndToEndProtection = xmlItem.find('./USES-END-TO-END-PROTECTION')
             if usesEndToEndProtection != None:
-                comspec.usesEndToEndProtection = True if self.parseTextNode(usesEndToEndProtection)=='true' else False
+                comspec.usesEndToEndProtection = self.parseBooleanNode(usesEndToEndProtection)
 
             port._comspec.provided.append(comspec)
         elif xmlItem.tag == 'QUEUED-SENDER-COM-SPEC':

--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -217,10 +217,18 @@ class ComponentTypeParser(EntityParser):
                 if xmlElem != None:
                     comspec.initValue, comspec.initValueRef = self._parseAr4InitValue(xmlElem)
             else:
-                if xmlItem.find('./INIT-VALUE-REF') is not None:
-                    comspec.initValueRef = self.parseTextNode(xmlItem.find('./INIT-VALUE-REF'))
-            if xmlItem.find('./CAN-INVALIDATE') != None:
-                comspec.canInvalidate = True if self.parseTextNode(xmlItem.find('./CAN-INVALIDATE'))=='true' else False
+                initValueRef = xmlItem.find('./INIT-VALUE-REF')
+                if initValueRef is not None:
+                    comspec.initValueRef = self.parseTextNode(initValueRef)
+
+            canInvalidate = xmlItem.find('./CAN-INVALIDATE')
+            if canInvalidate != None:
+                comspec.canInvalidate = True if self.parseTextNode(canInvalidate)=='true' else False
+
+            usesEndToEndProtection = xmlItem.find('./USES-END-TO-END-PROTECTION')
+            if usesEndToEndProtection != None:
+                comspec.useEndToEndProtection = True if self.parseTextNode(usesEndToEndProtection)=='true' else False
+
             port._comspec.provided.append(comspec)
         elif xmlItem.tag == 'QUEUED-SENDER-COM-SPEC':
             dataElemName = _getDataElemNameFromComSpec(xmlItem,portInterfaceRef)

--- a/autosar/parser/component_parser.py
+++ b/autosar/parser/component_parser.py
@@ -221,13 +221,17 @@ class ComponentTypeParser(EntityParser):
                 if initValueRef is not None:
                     comspec.initValueRef = self.parseTextNode(initValueRef)
 
+            enableUpdate = xmlItem.find('./ENABLE-UPDATE')
+            if enableUpdate != None:
+                comspec.enableUpdate = True if self.parseTextNode(enableUpdate)=='true' else False
+
             canInvalidate = xmlItem.find('./CAN-INVALIDATE')
             if canInvalidate != None:
                 comspec.canInvalidate = True if self.parseTextNode(canInvalidate)=='true' else False
 
             usesEndToEndProtection = xmlItem.find('./USES-END-TO-END-PROTECTION')
             if usesEndToEndProtection != None:
-                comspec.useEndToEndProtection = True if self.parseTextNode(usesEndToEndProtection)=='true' else False
+                comspec.usesEndToEndProtection = True if self.parseTextNode(usesEndToEndProtection)=='true' else False
 
             port._comspec.provided.append(comspec)
         elif xmlItem.tag == 'QUEUED-SENDER-COM-SPEC':

--- a/autosar/port.py
+++ b/autosar/port.py
@@ -16,8 +16,8 @@ import collections
 
 from autosar.util.errorHandler import handleNotImplementedError
 
-sender_receiver_com_spec_arguments_ar4 = {'dataElement', 'initValue', 'initValueRef', 'aliveTimeout', 'queueLength'}
-sender_receiver_com_spec_arguments_ar3 = {'dataElement', 'canInvalidate', 'initValueRef', 'aliveTimeout', 'queueLength'}
+sender_receiver_com_spec_arguments_ar4 = {'dataElement', 'initValue', 'initValueRef', 'aliveTimeout', 'queueLength', 'usesEndToEndProtection'}
+sender_receiver_com_spec_arguments_ar3 = {'dataElement', 'canInvalidate', 'initValueRef', 'aliveTimeout', 'queueLength', 'usesEndToEndProtection'}
 client_server_com_spec_arguments = {'operation', 'queueLength'}
 mode_switch_com_spec_arguments = {'enhancedMode', 'supportAsync', 'queueLength', 'modeSwitchAckTimeout', 'modeGroup'}
 parameter_com_spec_arguments = {'parameter', 'initValue'}
@@ -444,7 +444,7 @@ class DataElementComSpec(ComSpec):
         self._queueLength = int(queueLength) if queueLength is not None else None
         self.canInvalidate = bool(canInvalidate) if canInvalidate is not None else None
         self.enableUpdate = bool(enableUpdate) if enableUpdate is not None else None
-        self.usesEndToEndProtection = bool(usesEndToEndProtection) if usesEndToEndProtection is not None else None
+        self.usesEndToEndProtection = bool(usesEndToEndProtection) if usesEndToEndProtection is not None else False
 
     @property
     def aliveTimeout(self):

--- a/autosar/port.py
+++ b/autosar/port.py
@@ -16,8 +16,8 @@ import collections
 
 from autosar.util.errorHandler import handleNotImplementedError
 
-sender_receiver_com_spec_arguments_ar4 = {'dataElement', 'initValue', 'initValueRef', 'aliveTimeout', 'queueLength', 'usesEndToEndProtection'}
-sender_receiver_com_spec_arguments_ar3 = {'dataElement', 'canInvalidate', 'initValueRef', 'aliveTimeout', 'queueLength', 'usesEndToEndProtection'}
+sender_receiver_com_spec_arguments_ar4 = {'dataElement', 'initValue', 'initValueRef', 'aliveTimeout', 'queueLength', 'enableUpdate', 'usesEndToEndProtection'}
+sender_receiver_com_spec_arguments_ar3 = {'dataElement', 'canInvalidate', 'initValueRef', 'aliveTimeout', 'queueLength', 'enableUpdate', 'usesEndToEndProtection'}
 client_server_com_spec_arguments = {'operation', 'queueLength'}
 mode_switch_com_spec_arguments = {'enhancedMode', 'supportAsync', 'queueLength', 'modeSwitchAckTimeout', 'modeGroup'}
 parameter_com_spec_arguments = {'parameter', 'initValue'}
@@ -444,7 +444,7 @@ class DataElementComSpec(ComSpec):
         self._queueLength = int(queueLength) if queueLength is not None else None
         self.canInvalidate = bool(canInvalidate) if canInvalidate is not None else None
         self.enableUpdate = bool(enableUpdate) if enableUpdate is not None else None
-        self.usesEndToEndProtection = bool(usesEndToEndProtection) if usesEndToEndProtection is not None else False
+        self.usesEndToEndProtection = bool(usesEndToEndProtection) if usesEndToEndProtection is not None else None
 
     @property
     def aliveTimeout(self):

--- a/autosar/port.py
+++ b/autosar/port.py
@@ -93,6 +93,7 @@ class Port(Element):
             if 'aliveTimeout' in comspec: aliveTimeout=int(comspec['aliveTimeout'])
             if 'queueLength' in comspec: queueLength=int(comspec['queueLength'])
             if 'canInvalidate' in comspec: canInvalidate=bool(comspec['canInvalidate'])
+            if 'usesEndToEndProtection' in comspec: usesEndToEndProtection=bool(comspec['usesEndToEndProtection'])
             if (dataElementName is None) and (len(portInterface.dataElements)==1):
                 dataElementName=portInterface.dataElements[0].name
             #verify dataElementName
@@ -131,7 +132,7 @@ class Port(Element):
                     initValue = valueBuilder.buildFromDataType(dataType, rawInitValue)
                 else:
                     raise ValueError('initValue must be an instance of (autosar.constant.Value, int, float, str)')
-            return DataElementComSpec(dataElement.name, initValue, initValueRef, aliveTimeout, queueLength, canInvalidate)
+            return DataElementComSpec(dataElement.name, initValue, initValueRef, aliveTimeout, queueLength, canInvalidate, usesEndToEndProtection)
         elif isinstance(portInterface,autosar.portinterface.ClientServerInterface):
             operation = comspec.get('operation', None)
             queueLength = comspec.get('queueLength', 1)
@@ -430,7 +431,7 @@ class OperationComSpec(ComSpec):
         self.queueLength=queueLength
 
 class DataElementComSpec(ComSpec):
-    def __init__(self, name=None, initValue=None, initValueRef=None, aliveTimeout=None, queueLength=None, canInvalidate=None, useEndToEndProtection = None):
+    def __init__(self, name=None, initValue=None, initValueRef=None, aliveTimeout=None, queueLength=None, canInvalidate=None, usesEndToEndProtection = None):
         super().__init__(name)
         if initValue is not None:
             assert(isinstance(initValue, (autosar.constant.Value, autosar.constant.ValueAR4)))
@@ -439,7 +440,7 @@ class DataElementComSpec(ComSpec):
         self._aliveTimeout = int(aliveTimeout) if aliveTimeout is not None else None
         self._queueLength = int(queueLength) if queueLength is not None else None
         self.canInvalidate = bool(canInvalidate) if canInvalidate is not None else None
-        self.useEndToEndProtection = bool(useEndToEndProtection) if useEndToEndProtection is not None else None
+        self.usesEndToEndProtection = bool(usesEndToEndProtection) if usesEndToEndProtection is not None else None
 
     @property
     def aliveTimeout(self):

--- a/autosar/port.py
+++ b/autosar/port.py
@@ -86,6 +86,8 @@ class Port(Element):
             aliveTimeout = 0
             queueLength = None
             canInvalidate = False if isinstance(self,ProvidePort) else None
+            enableUpdate = False
+            usesEndToEndProtection = False
 
             if 'dataElement' in comspec: dataElementName=str(comspec['dataElement'])
             if 'initValue' in comspec: rawInitValue=comspec['initValue']
@@ -93,6 +95,7 @@ class Port(Element):
             if 'aliveTimeout' in comspec: aliveTimeout=int(comspec['aliveTimeout'])
             if 'queueLength' in comspec: queueLength=int(comspec['queueLength'])
             if 'canInvalidate' in comspec: canInvalidate=bool(comspec['canInvalidate'])
+            if 'enableUpdate' in comspec: enableUpdate=bool(comspec['enableUpdate'])
             if 'usesEndToEndProtection' in comspec: usesEndToEndProtection=bool(comspec['usesEndToEndProtection'])
             if (dataElementName is None) and (len(portInterface.dataElements)==1):
                 dataElementName=portInterface.dataElements[0].name
@@ -132,7 +135,7 @@ class Port(Element):
                     initValue = valueBuilder.buildFromDataType(dataType, rawInitValue)
                 else:
                     raise ValueError('initValue must be an instance of (autosar.constant.Value, int, float, str)')
-            return DataElementComSpec(dataElement.name, initValue, initValueRef, aliveTimeout, queueLength, canInvalidate, usesEndToEndProtection)
+            return DataElementComSpec(dataElement.name, initValue, initValueRef, aliveTimeout, queueLength, canInvalidate, enableUpdate, usesEndToEndProtection)
         elif isinstance(portInterface,autosar.portinterface.ClientServerInterface):
             operation = comspec.get('operation', None)
             queueLength = comspec.get('queueLength', 1)
@@ -431,7 +434,7 @@ class OperationComSpec(ComSpec):
         self.queueLength=queueLength
 
 class DataElementComSpec(ComSpec):
-    def __init__(self, name=None, initValue=None, initValueRef=None, aliveTimeout=None, queueLength=None, canInvalidate=None, usesEndToEndProtection = None):
+    def __init__(self, name=None, initValue=None, initValueRef=None, aliveTimeout=None, queueLength=None, canInvalidate=None, enableUpdate=None, usesEndToEndProtection = None):
         super().__init__(name)
         if initValue is not None:
             assert(isinstance(initValue, (autosar.constant.Value, autosar.constant.ValueAR4)))
@@ -440,6 +443,7 @@ class DataElementComSpec(ComSpec):
         self._aliveTimeout = int(aliveTimeout) if aliveTimeout is not None else None
         self._queueLength = int(queueLength) if queueLength is not None else None
         self.canInvalidate = bool(canInvalidate) if canInvalidate is not None else None
+        self.enableUpdate = bool(enableUpdate) if enableUpdate is not None else None
         self.usesEndToEndProtection = bool(usesEndToEndProtection) if usesEndToEndProtection is not None else None
 
     @property

--- a/autosar/writer/component_writer.py
+++ b/autosar/writer/component_writer.py
@@ -240,8 +240,8 @@ class XMLComponentTypeWriter(ElementWriter):
         lines=[]
         lines.append('<QUEUED-SENDER-COM-SPEC>')
         lines.append(self.indent('<DATA-ELEMENT-REF DEST="%s">%s</DATA-ELEMENT-REF>'%(elem.tag(self.version),elem.ref),1))
-        if (self.version>=4.0 and comspec.useEndToEndProtection is not None):
-            lines.append(self.indent('<USES-END-TO-END-PROTECTION>{}</USES-END-TO-END-PROTECTION>'.format(self.toBooleanStr(comspec.useEndToEndProtection)), 1))
+        if (self.version>=4.0 and comspec.usesEndToEndProtection is not None):
+            lines.append(self.indent('<USES-END-TO-END-PROTECTION>{}</USES-END-TO-END-PROTECTION>'.format(self.toBooleanStr(comspec.usesEndToEndProtection)), 1))
         lines.append('</QUEUED-SENDER-COM-SPEC>')
         return lines
 


### PR DESCRIPTION
This PR adds support for the:
- USES-END-TO-END-PROTECTION tag which indicates whether a Port requires E2E APIs
- ENABLE-UPDATE tag which enables the IsUpdate API to verify that a variable's value has been updated